### PR TITLE
Stop inflation of Indexer jobs

### DIFF
--- a/lib/BackgroundJobs/IndexerJob.php
+++ b/lib/BackgroundJobs/IndexerJob.php
@@ -126,7 +126,7 @@ class IndexerJob extends TimedJob {
 		$maxTime = $this->getMaxIndexingTime();
 		$startTime = time();
 		foreach ($files as $queueFile) {
-			if ($startTime + $maxTime > time()) {
+			if ($startTime + $maxTime < time()) {
 				break;
 			}
 			$file = current($this->rootFolder->getById($queueFile->getFileId()));

--- a/lib/BackgroundJobs/IndexerJob.php
+++ b/lib/BackgroundJobs/IndexerJob.php
@@ -30,7 +30,7 @@ use Psr\Log\LoggerInterface;
 
 class IndexerJob extends TimedJob {
 
-	public const DEAFULT_MAX_INDEXING_TIME = 5 * 60;
+	public const DEFAULT_MAX_INDEXING_TIME = 5 * 60;
 
 	public function __construct(
 		ITimeFactory            $time,
@@ -114,7 +114,7 @@ class IndexerJob extends TimedJob {
 	}
 
 	protected function getMaxIndexingTime(): int {
-		return $this->appConfig->getAppValue('indexing_max_time', self::DEFAULT_MAX_INDEXING_TIME);
+		return $this->appConfig->getAppValueInt('indexing_max_time', self::DEFAULT_MAX_INDEXING_TIME);
 	}
 
 	/**


### PR DESCRIPTION
This makes sure that each indexer job for each storage does not run longer than it's schedule interval, to avoid running the same job in multiple cron instances.