### PR TITLE
Remove logo from appstore screenshots

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,6 @@ Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/contex
     <category>integration</category>
     <website>https://github.com/nextcloud/context_chat</website>
     <bugs>https://github.com/nextcloud/context_chat/issues</bugs>
-    <screenshot>https://raw.githubusercontent.com/nextcloud/context_chat/main/img/Logo.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/context_chat/main/screenshots/context_chat_1.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/context_chat/main/screenshots/context_chat_2.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/context_chat/main/screenshots/context_chat_4.png</screenshot>


### PR DESCRIPTION
Case | Screen
---|---
Feels kind of weird on the apps page in the store: https://apps.nextcloud.com/apps/context_chat | ![grafik](https://github.com/user-attachments/assets/e55df719-bea9-44b0-8799-751b5afb5aeb)
And also in the overview it feels weird: | ![grafik](https://github.com/user-attachments/assets/dd9bde07-9b9e-4a33-a5f5-c8c0dd968c52)
