### PR TITLE
fix(ActionService): Don't schedule updates with empty userIds array

### DIFF
--- a/lib/Service/ActionService.php
+++ b/lib/Service/ActionService.php
@@ -96,6 +96,10 @@ class ActionService {
 	 * @return void
 	 */
 	public function updateAccess(string $op, array $userIds, string $sourceId): void {
+		if (count($userIds) === 0) {
+			$this->logger->warning('userIds array is empty, ignoring this update', ['sourceId' => $sourceId]);
+			return;
+		}
 		$payload = json_encode(['op' => $op, 'userIds' => $userIds, 'sourceId' => $sourceId]);
 		if ($payload === false) {
 			$this->logger->warning('Failed to json_encode access update for source', ['op' => $op, 'sourceId' => $sourceId]);
@@ -111,6 +115,10 @@ class ActionService {
 	 * @return void
 	 */
 	public function updateAccessProvider(string $op, array $userIds, string $providerId): void {
+		if (count($userIds) === 0) {
+			$this->logger->warning('userIds array is empty, ignoring this update', ['sourceId' => $providerId]);
+			return;
+		}
 		$payload = json_encode(['op' => $op, 'userIds' => $userIds, 'providerId' => $providerId]);
 		if ($payload === false) {
 			$this->logger->warning('Failed to json_encode access update for provider', ['op' => $op, 'providerId' => $providerId]);
@@ -125,6 +133,10 @@ class ActionService {
 	 * @return void
 	 */
 	public function updateAccessDeclSource(array $userIds, string $sourceId): void {
+		if (count($userIds) === 0) {
+			$this->logger->warning('userIds array is empty, ignoring this update', ['sourceId' => $sourceId]);
+			return;
+		}
 		$payload = json_encode(['userIds' => $userIds, 'sourceId' => $sourceId]);
 		if ($payload === false) {
 			$this->logger->warning('Failed to json_encode access update declarative for source', ['sourceId' => $sourceId]);


### PR DESCRIPTION
fixes #115

Alternatively, we could just delete the source in these cases, but that should perhaps be done explicitly, I think. What do you think?