### PR TITLE
fix: ensure that array key exists before accessing

### DIFF
--- a/lib/Listener/FileListener.php
+++ b/lib/Listener/FileListener.php
@@ -125,7 +125,8 @@ class FileListener implements IEventListener {
 				// If we just added this mount, ignore the removal, as the 'removal' event is always fired after
 				// the 'added' event in server
 				$rootId = $event->mountPoint->getRootId();
-				if ($this->addedMounts[$event->mountPoint->getUser()->getUID() . '-' . $rootId] === true) {
+				$mountKey = $event->mountPoint->getUser()->getUID() . '-' . $rootId;
+				if (array_key_exists($mountKey, $this->addedMounts) && $this->addedMounts[$mountKey] === true) {
 					$this->fsEventScheduler->retractAccessUpdateDecl($rootId);
 					return;
 				}


### PR DESCRIPTION
Hi,

I’ve run into that warning in Sentry. I don’t have a working setup with `context_chat`, and therefore the patch is untested. If I'm reading the stack trace correctly, then setting up the mounts is initiated at https://github.com/nextcloud/server/blob/7268525a8a13807441280376f7ec70b6fcad2845/lib/base.php#L886-L887.

```
ErrorException: Warning: Undefined array key "userid123-mountid456"
#31 /context_chat/lib/Listener/FileListener.php(128): OCA\ContextChat\Listener\FileListener::handle
#30 /lib/private/EventDispatcher/ServiceEventListener.php(68): OC\EventDispatcher\ServiceEventListener::__invoke
#29 /3rdparty/symfony/event-dispatcher/EventDispatcher.php(220): Symfony\Component\EventDispatcher\EventDispatcher::callListeners
#28 /3rdparty/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\Component\EventDispatcher\EventDispatcher::dispatch
#27 /lib/private/EventDispatcher/EventDispatcher.php(67): OC\EventDispatcher\EventDispatcher::dispatch
#26 /lib/private/EventDispatcher/EventDispatcher.php(79): OC\EventDispatcher\EventDispatcher::dispatchTyped
#25 /lib/private/Files/Config/UserMountCache.php(130): OC\Files\Config\UserMountCache::registerMounts
#24 /lib/private/Files/SetupManager.php(295): OC\Files\SetupManager::afterUserFullySetup
#23 /lib/private/Files/SetupManager.php(211): OC\Files\SetupManager::setupForUser
#22 /lib/private/Files/Filesystem.php(332): OC\Files\Filesystem::initMountPoints
#21 /lib/private/Cache/File.php(37): OC\Cache\File::getStorage
#20 /lib/private/Cache/File.php(158): OC\Cache\File::gc
#19 /lib/base.php(875): OC::{closure}
#18 [internal](0): call_user_func_array
#17 /lib/private/Hooks/EmitterTrait.php(88): OC\Hooks\BasicEmitter::emit
#16 /lib/private/Hooks/PublicEmitter.php(22): OC\Hooks\PublicEmitter::emit
#15 /lib/private/User/Session.php(350): OC\User\Session::completeLogin
#14 /lib/private/User/Session.php(619): OC\User\Session::loginWithToken
#13 /lib/private/User/Session.php(305): OC\User\Session::login
#12 /lib/private/User/Session.php(405): OC\User\Session::logClientIn
#11 /dav/lib/Connector/Sabre/Auth.php(80): OCA\DAV\Connector\Sabre\Auth::validateUserPass
#10 /3rdparty/sabre/dav/lib/DAV/Auth/Backend/AbstractBasic.php(103): Sabre\DAV\Auth\Backend\AbstractBasic::check
#9 /dav/lib/Connector/Sabre/Auth.php(191): OCA\DAV\Connector\Sabre\Auth::auth
#8 /dav/lib/Connector/Sabre/Auth.php(105): OCA\DAV\Connector\Sabre\Auth::check
#7 /3rdparty/sabre/dav/lib/DAV/Auth/Plugin.php(179): Sabre\DAV\Auth\Plugin::check
#6 /3rdparty/sabre/dav/lib/DAV/Auth/Plugin.php(135): Sabre\DAV\Auth\Plugin::beforeMethod
#5 /3rdparty/sabre/event/lib/WildcardEmitterTrait.php(89): Sabre\DAV\Server::emit
#4 /3rdparty/sabre/dav/lib/DAV/Server.php(456): Sabre\DAV\Server::invokeMethod
#3 /dav/lib/Connector/Sabre/Server.php(49): OCA\DAV\Connector\Sabre\Server::start
#2 /dav/lib/Server.php(401): OCA\DAV\Server::exec
#1 /dav/appinfo/v2/remote.php(21): require_once
#0 /remote.php(145): null
```