### PR TITLE
4.5.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.5.0-beta.0] - 2025-08-29
+
+### Added
+* feat: Add stats entry for queued unseen files (#161) @marcelklehr
+
+### Fixed
+* fix(makefile): Don't add stubs directory to release (#160) @marcelklehr
+* fix(QueueMappers): Ensure the queues are FIFO, prioritize (#161) @marcelklehr
+* fix: improve error handling (#161) @marcelklehr
+* fix(FsEventMapper): Prevent inserting duplicates (#161) @marcelklehr
+* fix(FileSystemListenerJob): Prevent OOM by working per user and tearing down FS in between (#161) @marcelklehr
+* fix(FileSystemListenerJob) Use SetupManager to tear down fs (#161) @marcelklehr
+* fix: Add RemoveDuplicateFsEvents repair step (#161) @marcelklehr
+* tests: Kill workers manually after each test case (#161) @marcelklehr
+* fix: Add comments to RemoveDuplicateFsEvents (#161) @marcelklehr
+* fix(IndexerJob): Make sure too large files are removed from queue (#161) @marcelklehr
+* fix(REUSE): Add copyright to psalm-baseline.xml (#161) @marcelklehr
+* fix: consider only new files for first indexing complete check (#161) @kyteinsky
+* wrap remove duplicate fs events db query in a transaction (#161) @kyteinsky
+* fix: adjustments to admin stats page (#161) @kyteinsky
+* fix: remove unopenable files from queue + add more logs (#161) @kyteinsky
+* fix: exclude trashbin and versions from total file estimate (#161) @kyteinsky
+* fix: improve logging and exception handling (#161) @kyteinsky
+* fix: handle empty list returned in ccb doc count (#161) @kyteinsky
+* fix: better db error handling in fs listener job (#161) @kyteinsky
+* do not deduplicate the fs events table at once (#161) @kyteinsky
+* fix: progressive de-duplication instead of all at once (#161) @kyteinsky
+* fix(IndexerJob): Fix warning message (#161) @marcelklehr
+* fix: only set last_indexed_file_id for the last successful file (#161) @kyteinsky
+* fix: Use MissingIndicesEvent instead of migration (#1661) @marcelklehr
+
+### Changed
+* perf: Schedule deletion in chunks + Don't create Node objects in a loop (#159) @marcelklehr
+* chore(settings): Move settings into assistant section (#162) @lukasdotcom
+* tests: background-job:worker -vv (#161) @marcelklehr
+
+
 ## [4.4.1] - 2025-07-31
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Setup background job workers as described here: https://docs.nextcloud.com/serve
 Note:
 Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/context_chat_backend/?tab=readme-ov-file) and the [AppAPI's documentation](https://cloud-py-api.github.io/app_api/) for help with setup of AppAPI's deploy daemon.
 ]]></description>
-    <version>4.4.2</version>
+    <version>4.5.0-beta.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <author>Anupam Kumar</author>


### PR DESCRIPTION
## [4.5.0-beta.0] - 2025-08-29

### Added
* feat: Add stats entry for queued unseen files (#161) @marcelklehr

### Fixed
* fix(makefile): Don't add stubs directory to release (#160) @marcelklehr
* fix(QueueMappers): Ensure the queues are FIFO, prioritize (#161) @marcelklehr
* fix: improve error handling (#161) @marcelklehr
* fix(FsEventMapper): Prevent inserting duplicates (#161) @marcelklehr
* fix(FileSystemListenerJob): Prevent OOM by working per user and tearing down FS in between (#161) @marcelklehr
* fix(FileSystemListenerJob) Use SetupManager to tear down fs (#161) @marcelklehr
* fix: Add RemoveDuplicateFsEvents repair step (#161) @marcelklehr
* tests: Kill workers manually after each test case (#161) @marcelklehr
* fix: Add comments to RemoveDuplicateFsEvents (#161) @marcelklehr
* fix(IndexerJob): Make sure too large files are removed from queue (#161) @marcelklehr
* fix(REUSE): Add copyright to psalm-baseline.xml (#161) @marcelklehr
* fix: consider only new files for first indexing complete check (#161) @kyteinsky
* wrap remove duplicate fs events db query in a transaction (#161) @kyteinsky
* fix: adjustments to admin stats page (#161) @kyteinsky
* fix: remove unopenable files from queue + add more logs (#161) @kyteinsky
* fix: exclude trashbin and versions from total file estimate (#161) @kyteinsky
* fix: improve logging and exception handling (#161) @kyteinsky
* fix: handle empty list returned in ccb doc count (#161) @kyteinsky
* fix: better db error handling in fs listener job (#161) @kyteinsky
* do not deduplicate the fs events table at once (#161) @kyteinsky
* fix: progressive de-duplication instead of all at once (#161) @kyteinsky
* fix(IndexerJob): Fix warning message (#161) @marcelklehr
* fix: only set last_indexed_file_id for the last successful file (#161) @kyteinsky
* fix: Use MissingIndicesEvent instead of migration (#1661) @marcelklehr

### Changed
* perf: Schedule deletion in chunks + Don't create Node objects in a loop (#159) @marcelklehr
* chore(settings): Move settings into assistant section (#162) @lukasdotcom
* tests: background-job:worker -vv (#161) @marcelklehr
