### PR TITLE
4.5.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+## [4.5.0-beta.2] - 2025-09-12
+
+### Changed
+* bump max NC version to 33
+
+### Fixed
+* fallback for empty file paths in Source construction (#172) @kyteinsky
+
+
 ## [4.5.0-beta.1] - 2025-09-09
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Setup background job workers as described here: https://docs.nextcloud.com/serve
 Note:
 Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/context_chat_backend/?tab=readme-ov-file) and the [AppAPI's documentation](https://cloud-py-api.github.io/app_api/) for help with setup of AppAPI's deploy daemon.
 ]]></description>
-    <version>4.5.0-beta.1</version>
+    <version>4.5.0-beta.2</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <author>Anupam Kumar</author>
@@ -40,7 +40,7 @@ Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/contex
     <screenshot>https://raw.githubusercontent.com/nextcloud/context_chat/main/screenshots/context_chat_4.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/context_chat/main/screenshots/context_chat_5.png</screenshot>
     <dependencies>
-        <nextcloud min-version="30" max-version="32"/>
+        <nextcloud min-version="30" max-version="33"/>
     </dependencies>
     <background-jobs>
 		<job>OCA\ContextChat\BackgroundJobs\FileSystemListenerJob</job>


### PR DESCRIPTION
## [4.5.0-beta.2] - 2025-09-12

### Changed
* bump max NC version to 33

### Fixed
* fallback for empty file paths in Source construction (#172) @kyteinsky
