### PR TITLE
5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.0.0] - 2025-10-15
+
+The public Content Manager API has been replaced and extended with the OCP API.
+For more details, see the [Nextcloud developer documentation](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/context_chat.html).
+
+### Changed
+* extend OCP API for public classes (#139) @edward-ly
+* bump minimum Nextcloud version to 32 (#139) @edward-ly
+* composer update (#184) @kyteinsky
+
+### Added
+* add isContextChatAvailable method to ContentManager (#139) @edward-ly
+* add public API change notice (#139) @edward-ly
+
+### Fixed
+* update docblock parameter types (#139) @edward-ly
+
 
 ## [4.5.0] - 2025-09-23
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Setup background job workers as described here: https://docs.nextcloud.com/serve
 Note:
 Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/context_chat_backend/?tab=readme-ov-file) and the [AppAPI's documentation](https://cloud-py-api.github.io/app_api/) for help with setup of AppAPI's deploy daemon.
 ]]></description>
-    <version>4.5.0</version>
+    <version>5.0.0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <author>Anupam Kumar</author>


### PR DESCRIPTION
## [5.0.0] - 2025-10-15

The public Content Manager API has been replaced and extended with the OCP API.
For more details, see the [Nextcloud developer documentation](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/context_chat.html).

### Changed
* extend OCP API for public classes (#139) @edward-ly
* bump minimum Nextcloud version to 32 (#139) @edward-ly
* composer update (#184) @kyteinsky

### Added
* add isContextChatAvailable method to ContentManager (#139) @edward-ly
* add public API change notice (#139) @edward-ly

### Fixed
* update docblock parameter types (#139) @edward-ly
