### PR TITLE
fix: add missing entity id in FsEventMapper::getFromQueue()

### DIFF
--- a/lib/Db/FsEventMapper.php
+++ b/lib/Db/FsEventMapper.php
@@ -72,7 +72,7 @@ class FsEventMapper extends QBMapper {
 	 */
 	public function getFromQueue(int $limit): array {
 		$qb = $this->db->getQueryBuilder();
-		$qb->selectDistinct(['user_id', 'type', 'node_id'])
+		$qb->selectDistinct(['id', 'user_id', 'type', 'node_id'])
 			->from($this->getTableName())
 			->setMaxResults($limit);
 


### PR DESCRIPTION
The FileSystemListener background job tries to delete events from the queue if the home-dir of the user cannot be found (e.g. because the user account has been removed):

https://github.com/nextcloud/context_chat/blob/f8566e58d3a384d67615163ef0ac4cf13f276746/lib/BackgroundJobs/FileSystemListenerJob.php#L104

However, this call to `FsEventMapper::delete()` cannot succeed if the entity id is missing, as is currently the case because ATM `FsEventMapper::getFromQueue()` omits the id in its result "entities" (which are in fact then only partial entities).

Another way to fix this would be to use `FsEventMapper::deleteByContent()` instead.

I stumbled over this cause of errors in the NC log like
```
 NoUserException Backends provided no user object /var/www/orgacloud/nextcloud/lib/private/Files/Node/Root.php:340
Backends provided no user object for [USER_ID]
```
with stack trace back to 

```
/var/www/orgacloud/nextcloud/apps/context_chat/lib/BackgroundJobs/FileSystemListenerJob.phpZeile 87
OC\Files\Node\LazyRoot->getUserFolder()
```

As such this is just ok and the effect of trying to access the home-directory of a no-longer existing user, but those messages do not go away, they appear over and over again because that delete attempt from

https://github.com/nextcloud/context_chat/blob/f8566e58d3a384d67615163ef0ac4cf13f276746/lib/BackgroundJobs/FileSystemListenerJob.php#L104

fails as the data returned by `FsEventMapper::getFromQueue()` does not include the entity id.