### PR TITLE
5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.2.1] - 2025-02-05
+
+### Changed
+* perf(FsEventScheduler): Make sure to get node owner from caller, if possible (#206) @marcelklehr
+* Migrate `getById` to `getFirstNodeById` (#211) @artonge
+* perf(FsEventService): Avoid fetching nodes (#213) @marcelklehr
+
+### Fixed
+* do not re-declare the id column in db models (#204) @kyteinsky
+* allow string IDs of oc_jobs from the snowflake change (#204) @kyteinsky
+
+
 ## [5.2.0] - 2025-01-08
 
 * bump to keep in sync with context_chat_backend minor version

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Setup background job workers as described here: https://docs.nextcloud.com/serve
 Note:
 Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/context_chat_backend/?tab=readme-ov-file) and the [AppAPI's documentation](https://cloud-py-api.github.io/app_api/) for help with setup of AppAPI's deploy daemon.
 ]]></description>
-    <version>5.2.0</version>
+    <version>5.2.1</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <author>Anupam Kumar</author>


### PR DESCRIPTION
### Changed
* perf(FsEventScheduler): Make sure to get node owner from caller, if possible (#206) @marcelklehr
* Migrate `getById` to `getFirstNodeById` (#211) @artonge
* perf(FsEventService): Avoid fetching nodes (#213) @marcelklehr

### Fixed
* do not re-declare the id column in db models (#204) @kyteinsky
* allow string IDs of oc_jobs from the snowflake change (#204) @kyteinsky
