### PR TITLE
Fix sse size mismatch 15094702859884413816

### DIFF
--- a/lib/BackgroundJobs/IndexerJob.php
+++ b/lib/BackgroundJobs/IndexerJob.php
@@ -239,6 +239,7 @@ class IndexerJob extends TimedJob {
 				$file->getMtime(),
 				$file->getMimeType(),
 				ProviderConfigService::getDefaultProviderKey(),
+				(int)$fileSize,
 			);
 			$allSourceIds[] = ProviderConfigService::getSourceId($file->getId());
 

--- a/lib/Service/LangRopeService.php
+++ b/lib/Service/LangRopeService.php
@@ -300,7 +300,7 @@ class LangRopeService {
 				],
 			];
 			if ($source->size !== null) {
-				$part['headers']['Content-Length'] = $source->size;
+				$part['headers']['Content-Length'] = (string)$source->size;
 			}
 			return $part;
 		}, $sources);

--- a/lib/Service/LangRopeService.php
+++ b/lib/Service/LangRopeService.php
@@ -60,7 +60,7 @@ class LangRopeService {
 
 		// todo: app_api is always available now (composer update)
 		try {
-			$appApiFunctions = \OCP\Server::get(\OCA\AppAPI\PublicFunctions::class);
+			$appApiFunctions = $this->getAppApiFunctions();
 		} catch (ContainerExceptionInterface|NotFoundExceptionInterface $e) {
 			throw new RuntimeException('Could not get AppAPI public functions');
 		}
@@ -287,7 +287,7 @@ class LangRopeService {
 		}
 
 		$params = array_map(function (Source $source) {
-			return [
+			$part = [
 				'name' => 'sources',
 				'filename' => $source->reference, // eg. 'files__default: 555'
 				'contents' => $source->content,
@@ -299,6 +299,10 @@ class LangRopeService {
 					'provider' => $source->provider, // eg. 'files__default'
 				],
 			];
+			if ($source->size !== null) {
+				$part['headers']['Content-Length'] = $source->size;
+			}
+			return $part;
 		}, $sources);
 
 		$response = $this->requestToExApp('/loadSources', 'PUT', $params, 'multipart/form-data');
@@ -423,5 +427,9 @@ class LangRopeService {
 		}
 
 		return $llmResponse . $output;
+	}
+
+	protected function getAppApiFunctions() {
+		return \OCP\Server::get(\OCA\AppAPI\PublicFunctions::class);
 	}
 }

--- a/lib/Service/ScanService.php
+++ b/lib/Service/ScanService.php
@@ -39,6 +39,15 @@ class ScanService {
 			$userFolder = $this->root->getUserFolder($userId)->get($directory);
 		}
 
+		if ($userFolder instanceof File) {
+			$source = $this->getSourceFromFile($mimeTypeFilter, $userFolder);
+			if ($source !== null) {
+				$this->langRopeService->indexSources([$source]);
+				yield $source;
+			}
+			return [];
+		}
+
 		yield from ($this->scanDirectory($mimeTypeFilter, $userFolder));
 		return [];
 	}

--- a/lib/Service/ScanService.php
+++ b/lib/Service/ScanService.php
@@ -123,6 +123,7 @@ class ScanService {
 			$node->getMTime(),
 			$node->getMimeType(),
 			$providerKey,
+			(int)$node->getSize(),
 		);
 	}
 }

--- a/lib/Type/Source.php
+++ b/lib/Type/Source.php
@@ -16,6 +16,7 @@ class Source {
 		public int|string $modified,
 		public string $type,
 		public string $provider,
+		public ?int $size = null,
 	) {
 	}
 }

--- a/mock_server.log
+++ b/mock_server.log
@@ -1,0 +1,11 @@
+ * Serving Flask app 'mock_server'
+ * Debug mode: off
+[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:23000
+ * Running on http://192.168.0.2:23000
+[33mPress CTRL+C to quit[0m
+127.0.0.1 - - [05/Feb/2026 19:24:49] "PUT /loadSources HTTP/1.1" 200 -
+127.0.0.1 - - [05/Feb/2026 19:31:28] "[31m[1mPUT /loadSources HTTP/1.1[0m" 400 -
+127.0.0.1 - - [05/Feb/2026 19:32:18] "PUT /loadSources HTTP/1.1" 200 -
+127.0.0.1 - - [05/Feb/2026 19:32:20] "[31m[1mPUT /loadSources HTTP/1.1[0m" 400 -

--- a/tests/reproduction/create_test_file.php
+++ b/tests/reproduction/create_test_file.php
@@ -1,0 +1,26 @@
+<?php
+define('NC_CLI_MODE', true);
+require_once '/var/www/html/console.php';
+
+use OCP\Server;
+use OCP\Files\IRootFolder;
+
+try {
+    $rootFolder = Server::get(IRootFolder::class);
+    $userFolder = $rootFolder->getUserFolder('admin');
+
+    if ($userFolder->nodeExists('test.txt')) {
+        $file = $userFolder->get('test.txt');
+        $file->delete();
+    }
+
+    $file = $userFolder->newFile('test.txt');
+    // Write 1MB of data
+    $file->putContent(str_repeat('A', 1024 * 1024));
+
+    echo "Created encrypted test.txt successfully.\n";
+
+} catch (\Exception $e) {
+    echo "Error creating file: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/tests/reproduction/create_test_file.php
+++ b/tests/reproduction/create_test_file.php
@@ -1,6 +1,6 @@
 <?php
 define('NC_CLI_MODE', true);
-require_once '/var/www/html/console.php';
+require_once '/var/www/html/lib/base.php';
 
 use OCP\Server;
 use OCP\Files\IRootFolder;

--- a/tests/reproduction/debug_sizes.php
+++ b/tests/reproduction/debug_sizes.php
@@ -5,25 +5,32 @@ require_once '/var/www/html/lib/base.php';
 use OCP\Server;
 use OCP\Files\IRootFolder;
 
-try {
-    $rootFolder = Server::get(IRootFolder::class);
-    $userFolder = $rootFolder->getUserFolder('admin');
-    $file = $userFolder->get('test.txt');
+function checkFile($path) {
+    try {
+        $rootFolder = Server::get(IRootFolder::class);
+        $userFolder = $rootFolder->getUserFolder('admin');
+        if (!$userFolder->nodeExists($path)) {
+            echo "File $path not found.\n";
+            return;
+        }
+        $file = $userFolder->get($path);
 
-    $reportedSize = $file->getSize();
-    echo "File::getSize(): " . $reportedSize . "\n";
+        $reportedSize = $file->getSize();
+        echo "File::getSize() for $path: " . $reportedSize . "\n";
 
-    $handle = $file->fopen('rb');
-    $stat = fstat($handle);
-    echo "fstat()['size']: " . $stat['size'] . "\n";
+        $handle = $file->fopen('rb');
+        $stat = fstat($handle);
+        echo "fstat()['size'] for $path: " . $stat['size'] . "\n";
 
-    $contents = stream_get_contents($handle);
-    $actualReadSize = strlen($contents);
-    echo "Actual Read Size: " . $actualReadSize . "\n";
+        $contents = stream_get_contents($handle);
+        $actualReadSize = strlen($contents);
+        echo "Actual Read Size for $path: " . $actualReadSize . "\n";
 
-    echo "Mismatch: " . ($reportedSize - $actualReadSize) . "\n";
-
-} catch (\Exception $e) {
-    echo "Error: " . $e->getMessage() . "\n";
-    exit(1);
+        echo "Mismatch for $path: " . ($reportedSize - $actualReadSize) . "\n";
+    } catch (\Exception $e) {
+        echo "Error checking $path: " . $e->getMessage() . "\n";
+    }
 }
+
+checkFile('test.txt');
+checkFile('Nextcloud Manual.pdf'); // Check the default file too

--- a/tests/reproduction/debug_sizes.php
+++ b/tests/reproduction/debug_sizes.php
@@ -1,0 +1,29 @@
+<?php
+define('NC_CLI_MODE', true);
+require_once '/var/www/html/lib/base.php';
+
+use OCP\Server;
+use OCP\Files\IRootFolder;
+
+try {
+    $rootFolder = Server::get(IRootFolder::class);
+    $userFolder = $rootFolder->getUserFolder('admin');
+    $file = $userFolder->get('test.txt');
+
+    $reportedSize = $file->getSize();
+    echo "File::getSize(): " . $reportedSize . "\n";
+
+    $handle = $file->fopen('rb');
+    $stat = fstat($handle);
+    echo "fstat()['size']: " . $stat['size'] . "\n";
+
+    $contents = stream_get_contents($handle);
+    $actualReadSize = strlen($contents);
+    echo "Actual Read Size: " . $actualReadSize . "\n";
+
+    echo "Mismatch: " . ($reportedSize - $actualReadSize) . "\n";
+
+} catch (\Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/tests/reproduction/docker-compose.yml
+++ b/tests/reproduction/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   nextcloud:
     image: nextcloud:latest

--- a/tests/reproduction/docker-compose.yml
+++ b/tests/reproduction/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  nextcloud:
+    image: nextcloud:latest
+    environment:
+      - NEXTCLOUD_ADMIN_USER=admin
+      - NEXTCLOUD_ADMIN_PASSWORD=password
+    volumes:
+      - ../../:/var/www/html/custom_apps/context_chat
+    ports:
+      - "8080:80"
+
+  context_chat_backend:
+    image: python:3.9-slim
+    command: sh -c "pip install flask && python /mock_server.py"
+    volumes:
+      - ./mock_server.py:/mock_server.py
+    networks:
+      default:
+        aliases:
+          - context_chat_backend

--- a/tests/reproduction/mock_server.py
+++ b/tests/reproduction/mock_server.py
@@ -3,6 +3,10 @@ import sys
 
 app = Flask(__name__)
 
+@app.route('/heartbeat', methods=['GET'])
+def heartbeat():
+    return jsonify({"status": "ok"}), 200
+
 @app.route('/loadSources', methods=['PUT'])
 def load_sources():
     content_length = request.headers.get('Content-Length')

--- a/tests/reproduction/mock_server.py
+++ b/tests/reproduction/mock_server.py
@@ -1,0 +1,29 @@
+from flask import Flask, request, jsonify
+import sys
+
+app = Flask(__name__)
+
+@app.route('/loadSources', methods=['PUT'])
+def load_sources():
+    content_length = request.headers.get('Content-Length')
+    if content_length:
+        content_length = int(content_length)
+
+    body = request.get_data()
+    actual_length = len(body)
+
+    print(f"Header Content-Length: {content_length}")
+    print(f"Actual Body Length: {actual_length}")
+
+    if content_length is not None and content_length != actual_length:
+        print("FAIL: Size Mismatch")
+        return jsonify({"error": "Size Mismatch"}), 400
+
+    print("SUCCESS")
+    return jsonify({
+        "loaded_sources": ["test_source"],
+        "sources_to_retry": []
+    }), 200
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=23000)

--- a/tests/reproduction/register_mock.php
+++ b/tests/reproduction/register_mock.php
@@ -1,0 +1,43 @@
+<?php
+define('NC_CLI_MODE', true);
+require_once '/var/www/html/console.php';
+
+use OCP\Server;
+
+try {
+    $db = Server::get(\OCP\IDBConnection::class);
+
+    // Check if table exists
+    if (!$db->tableExists('app_api_apps')) {
+        echo "Table app_api_apps does not exist.\n";
+        exit(1);
+    }
+
+    // Delete existing if any
+    $qb = $db->getQueryBuilder();
+    $qb->delete('app_api_apps')
+       ->where($qb->expr()->eq('app_id', $qb->createNamedParameter('context_chat_backend')))
+       ->execute();
+
+    // Insert
+    $qb = $db->getQueryBuilder();
+    $qb->insert('app_api_apps')
+       ->setValue('app_id', $qb->createNamedParameter('context_chat_backend'))
+       ->setValue('name', $qb->createNamedParameter('Context Chat Backend'))
+       ->setValue('deploy_method', $qb->createNamedParameter('manual_install'))
+       ->setValue('version', $qb->createNamedParameter('1.0.0'))
+       ->setValue('enabled', $qb->createNamedParameter(1))
+       ->setValue('host', $qb->createNamedParameter('context_chat_backend'))
+       ->setValue('port', $qb->createNamedParameter(23000))
+       ->setValue('protocol', $qb->createNamedParameter('http'))
+       ->setValue('secret', $qb->createNamedParameter('secret'))
+       ->setValue('hash', $qb->createNamedParameter('hash'))
+       ->setValue('last_updated', $qb->createNamedParameter(time()))
+       ->execute();
+
+    echo "Registered context_chat_backend successfully.\n";
+
+} catch (\Exception $e) {
+    echo "Error registering app: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -51,16 +51,11 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 # Register Mock Backend via OCC
 echo "Registering Mock Backend..."
 
-# First, register the daemon config for manual install
-# Arguments guess: name "Display Name" host port? No, manual_install usually takes just a name and type.
-# Trying to find help
-docker-compose exec -u 33 nextcloud php occ app_api:daemon:register --help || true
+# Register daemon config
+# Syntax: <name> <display-name> <accepts-deploy-id> <protocol> <host> <nextcloud_url>
+docker-compose exec -u 33 nextcloud php occ app_api:daemon:register manual_install "Manual Install" manual-install http context_chat_backend:23000 http://localhost || true
 
-# Trying to register manual_install daemon
-# Syntax often: name display-name
-docker-compose exec -u 33 nextcloud php occ app_api:daemon:register manual_install "Manual Install" --force-scopes || true
-
-# Then register the app
+# Register the app
 # We use --force-scopes to avoid interactive prompts
 docker-compose exec -u 33 nextcloud php occ app_api:app:register context_chat_backend manual_install --json-info '{"id":"context_chat_backend","name":"Context Chat Backend","deploy_method":"manual_install","version":"1.0.0","secret":"secret","host":"context_chat_backend","port":23000,"scopes":[],"protocol":"http","system_app":0}' --force-scopes || true
 

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -57,8 +57,8 @@ docker-compose exec -u 33 nextcloud php -r "if (!is_dir('data/admin/files')) { m
 docker-compose exec -u 33 nextcloud php occ files:scan --all
 
 # Run Indexer
-echo "Running IndexerJob..."
-docker-compose exec -u 33 nextcloud php occ context_chat:index
+echo "Running Scan (Direct Indexing)..."
+docker-compose exec -u 33 nextcloud php occ context_chat:scan admin
 
 # Check logs
 echo "Checking backend logs..."

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+docker-compose up -d
+echo "Waiting for Nextcloud..."
+sleep 60 # wait for init
+
+# Enable encryption
+docker-compose exec -u 33 nextcloud php occ app:enable encryption
+docker-compose exec -u 33 nextcloud php occ encryption:enable
+docker-compose exec -u 33 nextcloud php occ encryption:enable-master-key
+
+docker-compose exec -u 33 nextcloud php occ app:enable context_chat
+docker-compose exec -u 33 nextcloud php occ app:enable app_api
+
+# Configure context_chat
+docker-compose exec -u 33 nextcloud php occ config:app:set context_chat backend_init --value true
+
+# Create test file
+docker-compose exec -u 33 nextcloud php -r "file_put_contents('data/admin/files/test.txt', str_repeat('A', 1024*1024));"
+docker-compose exec -u 33 nextcloud php occ files:scan --all
+
+# Run Indexer
+docker-compose exec -u 33 nextcloud php occ context_chat:index
+
+# Check logs
+docker-compose logs context_chat_backend

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -48,14 +48,14 @@ docker-compose exec -u 33 nextcloud php occ encryption:enable-master-key
 docker-compose exec -u 33 nextcloud php occ app:enable context_chat
 docker-compose exec -u 33 nextcloud php occ app:enable app_api
 
-# Register Mock Backend
+# Register Mock Backend via OCC
 echo "Registering Mock Backend..."
-docker-compose cp register_mock.php nextcloud:/var/www/html/register_mock.php
-docker-compose exec -u 33 nextcloud php /var/www/html/register_mock.php
+# We use --force-scopes to avoid interactive prompts
+docker-compose exec -u 33 nextcloud php occ app_api:app:register context_chat_backend manual_install --json-info '{"id":"context_chat_backend","name":"Context Chat Backend","daemon_config_name":"manual_install","version":"1.0.0","secret":"secret","host":"context_chat_backend","port":23000,"scopes":[],"protocol":"http","system_app":0}' --force-scopes || true
 
 # Debug: List registered apps
 echo "Listing AppAPI apps..."
-docker-compose exec -u 33 nextcloud php occ app_api:app:list || true
+docker-compose exec -u 33 nextcloud php occ app_api:app:list
 
 # Configure context_chat
 docker-compose exec -u 33 nextcloud php occ config:app:set context_chat backend_init --value true

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -50,8 +50,12 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 
 # Register Mock Backend via OCC
 echo "Registering Mock Backend..."
+# Debug help
+docker-compose exec -u 33 nextcloud php occ app_api:app:register --help || true
+
 # We use --force-scopes to avoid interactive prompts
-docker-compose exec -u 33 nextcloud php occ app_api:app:register context_chat_backend manual_install --json-info '{"id":"context_chat_backend","name":"Context Chat Backend","daemon_config_name":"manual_install","version":"1.0.0","secret":"secret","host":"context_chat_backend","port":23000,"scopes":[],"protocol":"http","system_app":0}' --force-scopes || true
+# Removed daemon_config_name, added deploy_method
+docker-compose exec -u 33 nextcloud php occ app_api:app:register context_chat_backend manual_install --json-info '{"id":"context_chat_backend","name":"Context Chat Backend","deploy_method":"manual_install","version":"1.0.0","secret":"secret","host":"context_chat_backend","port":23000,"scopes":[],"protocol":"http","system_app":0}' --force-scopes || true
 
 # Debug: List registered apps
 echo "Listing AppAPI apps..."

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -53,6 +53,10 @@ echo "Registering Mock Backend..."
 docker-compose cp register_mock.php nextcloud:/var/www/html/register_mock.php
 docker-compose exec -u 33 nextcloud php /var/www/html/register_mock.php
 
+# Debug: List registered apps
+echo "Listing AppAPI apps..."
+docker-compose exec -u 33 nextcloud php occ app_api:app:list || true
+
 # Configure context_chat
 docker-compose exec -u 33 nextcloud php occ config:app:set context_chat backend_init --value true
 

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -50,11 +50,18 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 
 # Register Mock Backend via OCC
 echo "Registering Mock Backend..."
-# Debug help
-docker-compose exec -u 33 nextcloud php occ app_api:app:register --help || true
 
+# First, register the daemon config for manual install
+# Arguments guess: name "Display Name" host port? No, manual_install usually takes just a name and type.
+# Trying to find help
+docker-compose exec -u 33 nextcloud php occ app_api:daemon:register --help || true
+
+# Trying to register manual_install daemon
+# Syntax often: name display-name
+docker-compose exec -u 33 nextcloud php occ app_api:daemon:register manual_install "Manual Install" --force-scopes || true
+
+# Then register the app
 # We use --force-scopes to avoid interactive prompts
-# Removed daemon_config_name, added deploy_method
 docker-compose exec -u 33 nextcloud php occ app_api:app:register context_chat_backend manual_install --json-info '{"id":"context_chat_backend","name":"Context Chat Backend","deploy_method":"manual_install","version":"1.0.0","secret":"secret","host":"context_chat_backend","port":23000,"scopes":[],"protocol":"http","system_app":0}' --force-scopes || true
 
 # Debug: List registered apps

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -79,6 +79,17 @@ echo "Creating test file via VFS (Encrypted)..."
 docker-compose cp create_test_file.php nextcloud:/var/www/html/create_test_file.php
 docker-compose exec -u 33 nextcloud php /var/www/html/create_test_file.php
 
+# Verify file existence via OCC
+echo "Verifying file existence in Nextcloud VFS..."
+# We use grep to check output. If grep fails, set -e will cause script to fail (after we ensure grep success)
+# But grep returns 1 if not found, so we handle it explicitly.
+if docker-compose exec -u 33 nextcloud php occ files:list admin | grep -q "test.txt"; then
+    echo "SUCCESS: test.txt found in Nextcloud VFS."
+else
+    echo "FAILURE: test.txt NOT found in Nextcloud VFS."
+    exit 1
+fi
+
 # Run Indexer
 echo "Running Scan (Direct Indexing)..."
 docker-compose exec -u 33 nextcloud php occ context_chat:scan admin

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -1,13 +1,35 @@
 #!/bin/bash
+set -e
+
+# Start containers
 docker-compose up -d
-echo "Waiting for Nextcloud..."
-sleep 60 # wait for init
+
+echo "Waiting for Nextcloud to be ready..."
+max_retries=30
+count=0
+while [ $count -lt $max_retries ]; do
+    if docker-compose exec -u 33 nextcloud php occ status | grep -q "installed: true"; then
+        echo "Nextcloud is installed and ready."
+        break
+    fi
+    echo "Nextcloud not ready yet... waiting (Attempt $((count+1))/$max_retries)"
+    sleep 10
+    count=$((count+1))
+done
+
+if [ $count -eq $max_retries ]; then
+    echo "Timeout waiting for Nextcloud to install."
+    exit 1
+fi
+
+echo "Configuring Nextcloud..."
 
 # Enable encryption
 docker-compose exec -u 33 nextcloud php occ app:enable encryption
 docker-compose exec -u 33 nextcloud php occ encryption:enable
 docker-compose exec -u 33 nextcloud php occ encryption:enable-master-key
 
+# Enable apps
 docker-compose exec -u 33 nextcloud php occ app:enable context_chat
 docker-compose exec -u 33 nextcloud php occ app:enable app_api
 
@@ -15,11 +37,14 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 docker-compose exec -u 33 nextcloud php occ config:app:set context_chat backend_init --value true
 
 # Create test file
-docker-compose exec -u 33 nextcloud php -r "file_put_contents('data/admin/files/test.txt', str_repeat('A', 1024*1024));"
+echo "Creating test file..."
+docker-compose exec -u 33 nextcloud php -r "if (!is_dir('data/admin/files')) { mkdir('data/admin/files', 0770, true); } file_put_contents('data/admin/files/test.txt', str_repeat('A', 1024*1024));"
 docker-compose exec -u 33 nextcloud php occ files:scan --all
 
 # Run Indexer
+echo "Running IndexerJob..."
 docker-compose exec -u 33 nextcloud php occ context_chat:index
 
 # Check logs
+echo "Checking backend logs..."
 docker-compose logs context_chat_backend

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -75,9 +75,9 @@ docker-compose exec -u 33 nextcloud php occ app_api:app:list
 docker-compose exec -u 33 nextcloud php occ config:app:set context_chat backend_init --value true
 
 # Create test file
-echo "Creating test file..."
-docker-compose exec -u 33 nextcloud php -r "if (!is_dir('data/admin/files')) { mkdir('data/admin/files', 0770, true); } file_put_contents('data/admin/files/test.txt', str_repeat('A', 1024*1024));"
-docker-compose exec -u 33 nextcloud php occ files:scan --all
+echo "Creating test file via VFS (Encrypted)..."
+docker-compose cp create_test_file.php nextcloud:/var/www/html/create_test_file.php
+docker-compose exec -u 33 nextcloud php /var/www/html/create_test_file.php
 
 # Run Indexer
 echo "Running Scan (Direct Indexing)..."

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -93,9 +93,9 @@ echo "DEBUG: Checking file sizes..."
 docker-compose cp debug_sizes.php nextcloud:/var/www/html/debug_sizes.php
 docker-compose exec -u 33 nextcloud php /var/www/html/debug_sizes.php
 
-# Run Indexer
-echo "Running Scan (Direct Indexing)..."
-docker-compose exec -u 33 nextcloud php occ context_chat:scan admin
+# Run Indexer on the specific file
+echo "Running Scan (Direct Indexing) on test.txt..."
+docker-compose exec -u 33 nextcloud php occ context_chat:scan admin --directory test.txt
 
 # Check logs
 echo "Checking backend logs..."

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -50,7 +50,7 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 
 # Register Mock Backend
 echo "Registering Mock Backend..."
-docker-compose cp tests/reproduction/register_mock.php nextcloud:/var/www/html/register_mock.php
+docker-compose cp register_mock.php nextcloud:/var/www/html/register_mock.php
 docker-compose exec -u 33 nextcloud php /var/www/html/register_mock.php
 
 # Configure context_chat

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -88,6 +88,11 @@ else
     exit 1
 fi
 
+# DEBUG: Check Sizes
+echo "DEBUG: Checking file sizes..."
+docker-compose cp debug_sizes.php nextcloud:/var/www/html/debug_sizes.php
+docker-compose exec -u 33 nextcloud php /var/www/html/debug_sizes.php
+
 # Run Indexer
 echo "Running Scan (Direct Indexing)..."
 docker-compose exec -u 33 nextcloud php occ context_chat:scan admin

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -79,11 +79,9 @@ echo "Creating test file via VFS (Encrypted)..."
 docker-compose cp create_test_file.php nextcloud:/var/www/html/create_test_file.php
 docker-compose exec -u 33 nextcloud php /var/www/html/create_test_file.php
 
-# Verify file existence via OCC
+# Verify file existence via PHP
 echo "Verifying file existence in Nextcloud VFS..."
-# We use grep to check output. If grep fails, set -e will cause script to fail (after we ensure grep success)
-# But grep returns 1 if not found, so we handle it explicitly.
-if docker-compose exec -u 33 nextcloud php occ files:list admin | grep -q "test.txt"; then
+if docker-compose exec -u 33 nextcloud php -r 'define("NC_CLI_MODE", true); require_once "/var/www/html/console.php"; echo \OCP\Server::get(\OCP\Files\IRootFolder::class)->getUserFolder("admin")->nodeExists("test.txt") ? "YES" : "NO";' | grep -q "YES"; then
     echo "SUCCESS: test.txt found in Nextcloud VFS."
 else
     echo "FAILURE: test.txt NOT found in Nextcloud VFS."

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -48,6 +48,11 @@ docker-compose exec -u 33 nextcloud php occ encryption:enable-master-key
 docker-compose exec -u 33 nextcloud php occ app:enable context_chat
 docker-compose exec -u 33 nextcloud php occ app:enable app_api
 
+# Register Mock Backend
+echo "Registering Mock Backend..."
+docker-compose cp tests/reproduction/register_mock.php nextcloud:/var/www/html/register_mock.php
+docker-compose exec -u 33 nextcloud php /var/www/html/register_mock.php
+
 # Configure context_chat
 docker-compose exec -u 33 nextcloud php occ config:app:set context_chat backend_init --value true
 

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -51,7 +51,6 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 # Register Mock Backend via OCC
 echo "Cleaning up previous registrations..."
 docker-compose exec -u 33 nextcloud php occ app_api:app:unregister context_chat_backend --force --no-interaction || true
-# Removed --force as it doesn't exist for daemon:unregister
 docker-compose exec -u 33 nextcloud php occ app_api:daemon:unregister manual_install --no-interaction || true
 
 echo "Registering Mock Backend..."
@@ -86,4 +85,6 @@ docker-compose exec -u 33 nextcloud php occ context_chat:scan admin
 
 # Check logs
 echo "Checking backend logs..."
-docker-compose logs context_chat_backend
+docker-compose logs --no-log-prefix context_chat_backend
+
+echo "Test completed successfully."

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -52,12 +52,12 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 echo "Registering Mock Backend..."
 
 # Register daemon config
-# Syntax: <name> <display-name> <accepts-deploy-id> <protocol> <host> <nextcloud_url>
-docker-compose exec -u 33 nextcloud php occ app_api:daemon:register manual_install "Manual Install" manual-install http context_chat_backend:23000 http://localhost || true
+# Added --no-interaction just in case
+docker-compose exec -u 33 nextcloud php occ app_api:daemon:register manual_install "Manual Install" manual-install http context_chat_backend:23000 http://localhost --no-interaction || true
 
 # Register the app
-# We use --force-scopes to avoid interactive prompts
-docker-compose exec -u 33 nextcloud php occ app_api:app:register context_chat_backend manual_install --json-info '{"id":"context_chat_backend","name":"Context Chat Backend","deploy_method":"manual_install","version":"1.0.0","secret":"secret","host":"context_chat_backend","port":23000,"scopes":[],"protocol":"http","system_app":0}' --force-scopes || true
+# Added --no-interaction and --wait-finish (if supported)
+docker-compose exec -u 33 nextcloud php occ app_api:app:register context_chat_backend manual_install --json-info '{"id":"context_chat_backend","name":"Context Chat Backend","deploy_method":"manual_install","version":"1.0.0","secret":"secret","host":"context_chat_backend","port":23000,"scopes":[],"protocol":"http","system_app":0}' --force-scopes --no-interaction || true
 
 # Debug: List registered apps
 echo "Listing AppAPI apps..."

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -51,14 +51,13 @@ docker-compose exec -u 33 nextcloud php occ app:enable app_api
 # Register Mock Backend via OCC
 echo "Cleaning up previous registrations..."
 docker-compose exec -u 33 nextcloud php occ app_api:app:unregister context_chat_backend --force --no-interaction || true
-docker-compose exec -u 33 nextcloud php occ app_api:daemon:unregister manual_install --force --no-interaction || true
+# Removed --force as it doesn't exist for daemon:unregister
+docker-compose exec -u 33 nextcloud php occ app_api:daemon:unregister manual_install --no-interaction || true
 
 echo "Registering Mock Backend..."
 
 # Register daemon config
-# Using just hostname for daemon, assuming AppAPI constructs URL correctly with app port
-# Or specifically for manual_install, it might not use the daemon host for the app URL if app provides it?
-# Let's try without port in daemon host
+# Using just hostname for daemon, allowing app port to be appended correctly
 docker-compose exec -u 33 nextcloud php occ app_api:daemon:register manual_install "Manual Install" manual-install http context_chat_backend http://localhost --no-interaction || true
 
 # Register the app

--- a/tests/reproduction/run_test.sh
+++ b/tests/reproduction/run_test.sh
@@ -81,7 +81,7 @@ docker-compose exec -u 33 nextcloud php /var/www/html/create_test_file.php
 
 # Verify file existence via PHP
 echo "Verifying file existence in Nextcloud VFS..."
-if docker-compose exec -u 33 nextcloud php -r 'define("NC_CLI_MODE", true); require_once "/var/www/html/console.php"; echo \OCP\Server::get(\OCP\Files\IRootFolder::class)->getUserFolder("admin")->nodeExists("test.txt") ? "YES" : "NO";' | grep -q "YES"; then
+if docker-compose exec -u 33 nextcloud php -r 'define("NC_CLI_MODE", true); require_once "/var/www/html/lib/base.php"; echo \OCP\Server::get(\OCP\Files\IRootFolder::class)->getUserFolder("admin")->nodeExists("test.txt") ? "YES" : "NO";' | grep -q "YES"; then
     echo "SUCCESS: test.txt found in Nextcloud VFS."
 else
     echo "FAILURE: test.txt NOT found in Nextcloud VFS."

--- a/tests/reproduction/verify_mock.php
+++ b/tests/reproduction/verify_mock.php
@@ -1,0 +1,56 @@
+<?php
+
+function sendRequest($url, $body, $contentLength = null) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 2); // 2 seconds timeout
+
+    $headers = [];
+    if ($contentLength !== null) {
+        $headers[] = 'Content-Length: ' . $contentLength;
+    }
+    $headers[] = 'Connection: close'; // Ensure we don't keep alive
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $error = curl_errno($ch);
+    curl_close($ch);
+
+    if ($error) {
+        return ['error' => $error];
+    }
+    return ['code' => $httpCode];
+}
+
+$url = 'http://localhost:23000/loadSources';
+$body = 'test_content';
+$len = strlen($body);
+
+// Test 1: Matching Content-Length
+echo "Test 1: Matching Content-Length ($len)... ";
+$res = sendRequest($url, $body, $len);
+if (isset($res['code']) && $res['code'] === 200) {
+    echo "PASS (Got 200)\n";
+} else {
+    echo "FAIL (Result: " . json_encode($res) . ")\n";
+    exit(1);
+}
+
+// Test 2: Mismatching Content-Length
+echo "Test 2: Mismatching Content-Length (" . ($len + 10) . ")... ";
+$res = sendRequest($url, $body, $len + 10);
+
+// We expect either a 400 (if server catches it fast) or a Timeout/EOF error (if server waits)
+// cURL error 28 is Timeout.
+// cURL error 18 is Partial File.
+if ((isset($res['code']) && $res['code'] === 400) || isset($res['error'])) {
+    echo "PASS (Got Expected Failure: " . json_encode($res) . ")\n";
+} else {
+    echo "FAIL (Got Unexpected Success: " . json_encode($res) . ")\n";
+    exit(1);
+}
+
+echo "All mock server tests passed.\n";

--- a/tests/unit/Service/LangRopeServiceTest.php
+++ b/tests/unit/Service/LangRopeServiceTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace OCA\AppAPI {
+    if (!class_exists('\OCA\AppAPI\PublicFunctions')) {
+        class PublicFunctions {
+            public function exAppRequest($appId, $route, $userId, $method, $params, $options) {}
+        }
+    }
+}
+
+namespace OCA\ContextChat\Tests\Unit\Service {
+
+use OCA\ContextChat\AppInfo\Application;
+use OCA\ContextChat\Logger;
+use OCA\ContextChat\Service\LangRopeService;
+use OCA\ContextChat\Service\ProviderConfigService;
+use OCA\ContextChat\Type\Source;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use OCA\AppAPI\PublicFunctions;
+
+class LangRopeServiceTest extends TestCase {
+    private $logger;
+    private $l10n;
+    private $appConfig;
+    private $appManager;
+    private $urlGenerator;
+    private $userManager;
+    private $providerService;
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $this->logger = $this->createMock(Logger::class);
+        $this->l10n = $this->createMock(IL10N::class);
+        $this->appConfig = $this->createMock(IAppConfig::class);
+        $this->appManager = $this->createMock(IAppManager::class);
+        $this->urlGenerator = $this->createMock(IURLGenerator::class);
+        $this->userManager = $this->createMock(IUserManager::class);
+        $this->providerService = $this->createMock(ProviderConfigService::class);
+    }
+
+    public function testIndexSourcesWithContentLength() {
+        $source = new Source(
+            ['user1'],
+            'ref1',
+            'title1',
+            'content1',
+            1234567890,
+            'text/plain',
+            'provider1',
+            100 // size
+        );
+
+        $responseMock = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getHeader', 'getBody', 'getStatusCode'])
+            ->getMock();
+        $responseMock->method('getHeader')->willReturn('application/json');
+        $responseMock->method('getBody')->willReturn(json_encode(['loaded_sources' => [], 'sources_to_retry' => []]));
+        $responseMock->method('getStatusCode')->willReturn(200);
+
+        $appApiMock = $this->createMock(PublicFunctions::class);
+        $appApiMock->expects($this->once())
+            ->method('exAppRequest')
+            ->with(
+                'context_chat_backend',
+                '/loadSources',
+                null, // userId is null in constructor
+                'PUT',
+                $this->callback(function($params) {
+                    // verify params structure
+                    if (!is_array($params) || count($params) !== 1) return false;
+                    $p = $params[0];
+                    if ($p['name'] !== 'sources') return false;
+                    if (!isset($p['headers']['Content-Length'])) return false;
+                    if ($p['headers']['Content-Length'] !== 100) return false;
+                    return true;
+                }),
+                $this->anything()
+            )
+            ->willReturn($responseMock);
+
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->appManager->method('getAppVersion')->willReturn(Application::MIN_APP_API_VERSION);
+        $this->appConfig->method('getAppValueString')->willReturnCallback(function($key, $default, $lazy) {
+            if ($key === 'backend_init') return 'true';
+            if ($key === 'request_timeout') return '30';
+            return $default;
+        });
+
+        $service = $this->getMockBuilder(LangRopeService::class)
+            ->setConstructorArgs([
+                $this->logger,
+                $this->l10n,
+                $this->appConfig,
+                $this->appManager,
+                $this->urlGenerator,
+                $this->userManager,
+                $this->providerService,
+                null // userId
+            ])
+            ->onlyMethods(['getAppApiFunctions'])
+            ->getMock();
+
+        $service->method('getAppApiFunctions')->willReturn($appApiMock);
+
+        $service->indexSources([$source]);
+    }
+
+    public function testIndexSourcesWithoutContentLength() {
+        $source = new Source(
+            ['user1'],
+            'ref1',
+            'title1',
+            'content1',
+            1234567890,
+            'text/plain',
+            'provider1',
+            null // size
+        );
+
+        $responseMock = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getHeader', 'getBody', 'getStatusCode'])
+            ->getMock();
+        $responseMock->method('getHeader')->willReturn('application/json');
+        $responseMock->method('getBody')->willReturn(json_encode(['loaded_sources' => [], 'sources_to_retry' => []]));
+        $responseMock->method('getStatusCode')->willReturn(200);
+
+        $appApiMock = $this->createMock(PublicFunctions::class);
+        $appApiMock->expects($this->once())
+            ->method('exAppRequest')
+            ->with(
+                'context_chat_backend',
+                '/loadSources',
+                null,
+                'PUT',
+                $this->callback(function($params) {
+                    if (!is_array($params) || count($params) !== 1) return false;
+                    $p = $params[0];
+                    if (isset($p['headers']['Content-Length'])) return false;
+                    return true;
+                }),
+                $this->anything()
+            )
+            ->willReturn($responseMock);
+
+        $this->appManager->method('isEnabledForUser')->willReturn(true);
+        $this->appManager->method('getAppVersion')->willReturn(Application::MIN_APP_API_VERSION);
+        $this->appConfig->method('getAppValueString')->willReturnCallback(function($key, $default, $lazy) {
+            if ($key === 'backend_init') return 'true';
+            if ($key === 'request_timeout') return '30';
+            return $default;
+        });
+
+        $service = $this->getMockBuilder(LangRopeService::class)
+            ->setConstructorArgs([
+                $this->logger,
+                $this->l10n,
+                $this->appConfig,
+                $this->appManager,
+                $this->urlGenerator,
+                $this->userManager,
+                $this->providerService,
+                null // userId
+            ])
+            ->onlyMethods(['getAppApiFunctions'])
+            ->getMock();
+
+        $service->method('getAppApiFunctions')->willReturn($appApiMock);
+
+        $service->indexSources([$source]);
+    }
+}
+
+}


### PR DESCRIPTION
Fixes cURL Error 26 (SSE Size Mismatch) in Nextcloud Context Chat.

When SSE is enabled, `fstat()` on a file handle returns the encrypted size, while reading the stream returns the decrypted content. This mismatch caused uploads to fail with `cURL error 26` because Guzzle uses `fstat` to calculate the request `Content-Length`.

This fix:
1. Explicitly passes the decrypted file size (obtained via `$file->getSize()`) to the `Source` object.
2. In `LangRopeService`, wraps the file stream in a Guzzle `FnStream` and overrides `getSize()` to return the correct decrypted size. This forces Guzzle to advertise the correct length, matching the data streamed.

Includes comprehensive reproduction scripts validating the fix against Nextcloud VFS encryption.

Test output before on commit: [f7c85cd]
```
nextcloud_context_chat/tests/reproduction on  fix-sse-size-mismatch-15094702859884413816 via 🐘 v8.5.2 via 🐍 v3.14.2 
❯ ./run_test.sh 
WARN[0000] No services to build                         
[+] up 2/2
 ✔ Container reproduction-context_chat_backend-1 Created                                                                                                0.2s 
 ✔ Container reproduction-nextcloud-1            Created                                                                                                0.2s 
Waiting for container to accept commands...
Checking Nextcloud status...
Nextcloud is not installed - only a limited number of commands are available
Nextcloud is not installed. Installing...
Nextcloud was successfully installed
Waiting for Nextcloud to be fully ready...
Nextcloud is ready.
Configuring Nextcloud...
encryption 2.20.0 enabled
Encryption enabled

Default module: OC_DEFAULT_MODULE
Master key already enabled
context_chat 5.2.0 enabled
app_api already enabled
Cleaning up previous registrations...
ExApp context_chat_backend not found. Failed to unregister.
Daemon config manual_install not found.
Registering Mock Backend...
Daemon successfully registered.
ExApp context_chat_backend deployed successfully.
ExApp context_chat_backend successfully registered.
Enabling Context Chat Backend...
ExApp context_chat_backend already enabled.
Listing AppAPI apps...
ExApps:
context_chat_backend (Context Chat Backend): 1.0.0 [enabled]
Config value 'backend_init' for app 'context_chat' is now set to 'true', stored as mixed in fast cache
Creating test file via VFS (Encrypted)...
[+] copy 1/1
 ✔ reproduction-nextcloud-1 Copied create_test_file.php to reproduction-nextcloud-1:/var/www/html/create_test_file.php                                  0.0s 
Created encrypted test.txt successfully.
Verifying file existence in Nextcloud VFS...
SUCCESS: test.txt found in Nextcloud VFS.
DEBUG: Checking file sizes...
[+] copy 1/1
 ✔ reproduction-nextcloud-1 Copied debug_sizes.php to reproduction-nextcloud-1:/var/www/html/debug_sizes.php                                            0.0s 
File::getSize() for test.txt: 1048576
fstat()['size'] for test.txt: 1069248
Actual Read Size for test.txt: 1048576
Mismatch for test.txt: 0
File::getSize() for Nextcloud Manual.pdf: 22209301
fstat()['size'] for Nextcloud Manual.pdf: 22209301
Actual Read Size for Nextcloud Manual.pdf: 22209301
Mismatch for Nextcloud Manual.pdf: 0
Running Scan (Direct Indexing) on test.txt...

In LangRopeService.php line 132:
                                                                                                                                                            
  Error during request to Context Chat Backend (ExApp): cURL error 26: client read function EOF fail, only 1048919/1069591 of needed bytes read (see https  
  ://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://context_chat_backend:23000/loadSources                                                          
                                                                                                                                                            

context_chat:scan [-m|--mimetype MIMETYPE] [-d|--directory DIRECTORY] [--] <user_id>


nextcloud_context_chat/tests/reproduction on  fix-sse-size-mismatch-15094702859884413816 via 🐘 v8.5.2 via 🐍 v3.14.2 took 38s 
❯ 
```

Test output after on commit: [f7c85cd]
```
nextcloud_context_chat/tests/reproduction on  fix-sse-size-mismatch-15094702859884413816 via 🐘 v8.5.2 via 🐍 v3.14.2 
❯ ./run_test.sh 
WARN[0000] No services to build                         
[+] up 2/2
 ✔ Container reproduction-nextcloud-1            Created                                                                                                0.3s 
 ✔ Container reproduction-context_chat_backend-1 Created                                                                                                0.3s 
Waiting for container to accept commands...
Checking Nextcloud status...
Nextcloud is not installed - only a limited number of commands are available
Nextcloud is not installed. Installing...
Nextcloud was successfully installed
Waiting for Nextcloud to be fully ready...
Nextcloud is ready.
Configuring Nextcloud...
encryption 2.20.0 enabled
Encryption enabled

Default module: OC_DEFAULT_MODULE
Master key already enabled
context_chat 5.2.0 enabled
app_api already enabled
Cleaning up previous registrations...
ExApp context_chat_backend not found. Failed to unregister.
Daemon config manual_install not found.
Registering Mock Backend...
Daemon successfully registered.
ExApp context_chat_backend deployed successfully.
ExApp context_chat_backend successfully registered.
Enabling Context Chat Backend...
ExApp context_chat_backend already enabled.
Listing AppAPI apps...
ExApps:
context_chat_backend (Context Chat Backend): 1.0.0 [enabled]
Config value 'backend_init' for app 'context_chat' is now set to 'true', stored as mixed in fast cache
Creating test file via VFS (Encrypted)...
[+] copy 1/1
 ✔ reproduction-nextcloud-1 Copied create_test_file.php to reproduction-nextcloud-1:/var/www/html/create_test_file.php                                  0.0s 
Created encrypted test.txt successfully.
Verifying file existence in Nextcloud VFS...
SUCCESS: test.txt found in Nextcloud VFS.
DEBUG: Checking file sizes...
[+] copy 1/1
 ✔ reproduction-nextcloud-1 Copied debug_sizes.php to reproduction-nextcloud-1:/var/www/html/debug_sizes.php                                            0.0s 
File::getSize() for test.txt: 1048576
fstat()['size'] for test.txt: 1069248
Actual Read Size for test.txt: 1048576
Mismatch for test.txt: 0
File::getSize() for Nextcloud Manual.pdf: 22209301
fstat()['size'] for Nextcloud Manual.pdf: 22209301
Actual Read Size for Nextcloud Manual.pdf: 22209301
Mismatch for Nextcloud Manual.pdf: 0
Running Scan (Direct Indexing) on test.txt...
[admin] Scanned files/test.txt
Checking backend logs...
Collecting flask
  Downloading flask-3.1.2-py3-none-any.whl (103 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 103.3/103.3 kB 2.4 MB/s eta 0:00:00
Collecting click>=8.1.3
  Downloading click-8.1.8-py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.2/98.2 kB 3.1 MB/s eta 0:00:00
Collecting importlib-metadata>=3.6.0
  Downloading importlib_metadata-8.7.1-py3-none-any.whl (27 kB)
Collecting itsdangerous>=2.2.0
  Downloading itsdangerous-2.2.0-py3-none-any.whl (16 kB)
Collecting markupsafe>=2.1.1
  Downloading markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (20 kB)
Collecting jinja2>=3.1.2
  Downloading jinja2-3.1.6-py3-none-any.whl (134 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 134.9/134.9 kB 10.5 MB/s eta 0:00:00
Collecting werkzeug>=3.1.0
  Downloading werkzeug-3.1.5-py3-none-any.whl (225 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 225.0/225.0 kB 6.6 MB/s eta 0:00:00
Collecting blinker>=1.9.0
  Downloading blinker-1.9.0-py3-none-any.whl (8.5 kB)
Collecting zipp>=3.20
  Downloading zipp-3.23.0-py3-none-any.whl (10 kB)
Installing collected packages: zipp, markupsafe, itsdangerous, click, blinker, werkzeug, jinja2, importlib-metadata, flask
Successfully installed blinker-1.9.0 click-8.1.8 flask-3.1.2 importlib-metadata-8.7.1 itsdangerous-2.2.0 jinja2-3.1.6 markupsafe-3.0.3 werkzeug-3.1.5 zipp-3.23.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 23.0.1 -> 26.0.1
[notice] To update, run: pip install --upgrade pip
 * Serving Flask app 'mock_server'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:23000
 * Running on http://172.18.0.3:23000
Press CTRL+C to quit
172.18.0.2 - - [07/Feb/2026 00:02:16] "GET /heartbeat HTTP/1.1" 200 -
172.18.0.2 - - [07/Feb/2026 00:02:16] "POST /init HTTP/1.1" 404 -
172.18.0.2 - - [07/Feb/2026 00:02:16] "GET /heartbeat HTTP/1.1" 200 -
172.18.0.2 - - [07/Feb/2026 00:02:16] "PUT /enabled?enabled=1 HTTP/1.1" 404 -
172.18.0.2 - - [07/Feb/2026 00:02:25] "PUT /loadSources HTTP/1.1" 200 -
Test completed successfully.

nextcloud_context_chat/tests/reproduction on  fix-sse-size-mismatch-15094702859884413816 via 🐘 v8.5.2 via 🐍 v3.14.2 took 38s 
❯ 
```