### PR TITLE
fix(uncommited db transaction) FsEventMapper::insertRow() must not ...

### DIFF
--- a/lib/Db/FsEventMapper.php
+++ b/lib/Db/FsEventMapper.php
@@ -34,24 +34,23 @@ class FsEventMapper extends QBMapper {
 	}
 
 	public function insertRow(string $type, string $userId, int $nodeId): Entity {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->setMaxResults(1)
+			->where(
+				$qb->expr()->eq('user_id', $qb->createNamedParameter($userId)),
+				$qb->expr()->eq('type', $qb->createNamedParameter($type)),
+				$qb->expr()->eq('node_id', $qb->createNamedParameter($nodeId, IQueryBuilder::PARAM_INT)),
+			);
+		$entities = $this->findEntities($qb);
+
+		if (!empty($entities)) {
+			return $entities[0];
+		}
+
+		$this->db->beginTransaction();
 		try {
-			$this->db->beginTransaction();
-			$qb = $this->db->getQueryBuilder();
-			$qb->select('*')
-				->from($this->getTableName())
-				->setMaxResults(1)
-				->where(
-					$qb->expr()->eq('user_id', $qb->createNamedParameter($userId)),
-					$qb->expr()->eq('type', $qb->createNamedParameter($type)),
-					$qb->expr()->eq('node_id', $qb->createNamedParameter($nodeId, IQueryBuilder::PARAM_INT)),
-				);
-			$entities = $this->findEntities($qb);
-
-			if (!empty($entities)) {
-				$this->db->commit();
-				return $entities[0];
-			}
-
 			$entity = new FsEvent();
 			$entity->setUserId($userId);
 			$entity->setType($type);


### PR DESCRIPTION
… return from within an active transaction.

Why: the database connection is shared between all the code of the PHP script life-time. Opening another transaction from within an transaction is ok, but not committing that transaction is not ok as this will finally lead to a state where the script exits with positive transaction nesting level. This has the effect that ALL database mutations performed by ALL other modules (and also by the context_chat) module will just be discarded.

Thus, if any app does not properly commit all transaction frames it has started then "evil things" will happen ;)
