### PR TITLE
fix: handle array response in ex-app requests

### DIFF
--- a/lib/Service/LangRopeService.php
+++ b/lib/Service/LangRopeService.php
@@ -127,6 +127,13 @@ class LangRopeService {
 			$options,
 		);
 
+		if (is_array($response)) {
+			if (isset($response['error'])) {
+				throw new RuntimeException('Error received from Context Chat Backend (ExApp): ' . $response['error']);
+			}
+			return ['response' => $response];
+		}
+
 		$resContentType = $response->getHeader('Content-Type');
 		if (strpos($resContentType, 'application/json') !== false) {
 			$body = $response->getBody();


### PR DESCRIPTION
`occ context_chat:stats --json` throws an exception when context_chat_backend is down/unavailable. AppAPI returns an array with the error in this case.
```
Array
(
    [error] => cURL error 7: Failed to connect to host.docker.internal port 23034 after 2544 ms: Couldn't connect to server (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://host.docker.internal:23034/countIndexedDocuments
)
```

```
An unhandled exception has been thrown:
Error: Call to a member function getHeader() on array in /var/www/html/apps-shared/context_chat/lib/Service/LangRopeService.php:130
Stack trace:
#0 /var/www/html/apps-shared/context_chat/lib/Service/LangRopeService.php(184): OCA\ContextChat\Service\LangRopeService->requestToExApp('/countIndexedDo...', 'POST', Array, NULL, Array)
#1 /var/www/html/apps-shared/context_chat/lib/Service/StatisticsService.php(67): OCA\ContextChat\Service\LangRopeService->getIndexedDocumentsCounts()
#2 /var/www/html/apps-shared/context_chat/lib/Command/Statistics.php(39): OCA\ContextChat\Service\StatisticsService->getStatistics()
...
```