### PR TITLE
Respect auto_indexing during initial crawl scheduling

### DIFF
--- a/lib/BackgroundJobs/SchedulerJob.php
+++ b/lib/BackgroundJobs/SchedulerJob.php
@@ -34,6 +34,12 @@ class SchedulerJob extends QueuedJob {
 	 * @throws Exception
 	 */
 	protected function run($argument): void {
+		if ($this->appConfig->getAppValueString('auto_indexing', 'true', lazy: true) === 'false') {
+			$this->logger->debug('Skipping StorageCrawlJob scheduling because auto_indexing is disabled');
+			$this->jobList->remove(self::class);
+			return;
+		}
+
 		$this->appConfig->setAppValueInt('last_indexed_time', 0, lazy: true);
 		foreach ($this->storageService->getMounts() as $mount) {
 			$this->logger->debug('Scheduling StorageCrawlJob storage_id=' . $mount['storage_id'] . ' root_id=' . $mount['root_id' ] . 'override_root=' . $mount['overridden_root']);

--- a/lib/Repair/AppInstallStep.php
+++ b/lib/Repair/AppInstallStep.php
@@ -37,11 +37,14 @@ class AppInstallStep implements IRepairStep {
 		if ($this->appConfig->getAppValueInt('installed_time', 0, lazy: true) === 0) {
 			$this->logger->info('Setting up Context Chat for the first time');
 			$this->appConfig->setAppValueInt('installed_time', time(), lazy: true);
+			$autoIndexingEnabled = $this->appConfig->getAppValueString('auto_indexing', 'true', lazy: true) !== 'false';
 
 			// do not add SchedulerJob on every enable of the app
 			// so files are not added to the queue again when app is disabled and enabled
 			// in normal operation
-			$this->jobList->add(SchedulerJob::class);
+			if ($autoIndexingEnabled) {
+				$this->jobList->add(SchedulerJob::class);
+			}
 		}
 
 		$providerConfigService = new ProviderConfigService($this->appConfig);


### PR DESCRIPTION
Skip the initial scheduler crawl when auto_indexing is set to false, and keep the scheduled job from enqueuing mounts in that case.

Fixes #260