### PR TITLE
5.5.0-beta0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.5.0-beta0] - 2026-08-13
+
+### Added
+* add context_chat:reindex to re-seed the crawl on demand (#246) @bygadd
+* add NC 35 support (#256) @kyteinsky
+
+### Fixed
+* refactor(commands): Add type hinting to execute method in search command (#259) @CarlSchwan
+* fix(AppDisableListener): pass full provider key to deleteProvider (#265) @weltmaister
+
+
 ## [5.4.0] - 2026-06-24
 
 ### Highlights

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Setup background job workers as described here: https://docs.nextcloud.com/serve
 Note:
 Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/context_chat_backend/?tab=readme-ov-file) and the [AppAPI's documentation](https://cloud-py-api.github.io/app_api/) for help with setup of AppAPI's deploy daemon.
 ]]></description>
-    <version>5.4.0</version>
+    <version>5.5.0-beta0</version>
     <licence>agpl</licence>
     <author>Julien Veyssier</author>
     <author>Anupam Kumar</author>


### PR DESCRIPTION
## [5.5.0-beta0] - 2026-08-13

### Added
* add context_chat:reindex to re-seed the crawl on demand (#246) @bygadd
* add NC 35 support (#256) @kyteinsky

### Fixed
* refactor(commands): Add type hinting to execute method in search command (#259) @CarlSchwan
* fix(AppDisableListener): pass full provider key to deleteProvider (#265) @weltmaister

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
