### PR TITLE
Add tag-based document indexing allowlist

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -47,6 +47,7 @@ Refer to the [Context Chat Backend's readme](https://github.com/nextcloud/contex
 		<command>OCA\ContextChat\Command\Search</command>
 		<command>OCA\ContextChat\Command\Statistics</command>
 		<command>OCA\ContextChat\Command\Reindex</command>
+		<command>OCA\ContextChat\Command\CleanupUntagged</command>
 	</commands>
     <repair-steps>
         <install>

--- a/lib/BackgroundJobs/UntaggedCleanupCrawlJob.php
+++ b/lib/BackgroundJobs/UntaggedCleanupCrawlJob.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ContextChat\BackgroundJobs;
+
+use OCA\ContextChat\Logger;
+use OCA\ContextChat\Service\FsEventService;
+use OCA\ContextChat\Service\IndexCompletionService;
+use OCA\ContextChat\Service\StorageService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\Files\IRootFolder;
+
+/**
+ * For a single mount, walks all files in batches and removes from the
+ * index any file that does not have the "AI knowledge" tag. Mirrors
+ * StorageCrawlJob's batching/self-rescheduling shape, but for cleanup
+ * instead of indexing.
+ */
+class UntaggedCleanupCrawlJob extends QueuedJob {
+	public const BATCH_SIZE = 2000;
+	public const JOB_INTERVAL = 60;
+
+	public function __construct(
+		ITimeFactory $timeFactory,
+		private Logger $logger,
+		private IJobList $jobList,
+		private StorageService $storageService,
+		private FsEventService $fsEventService,
+		private IRootFolder $rootFolder,
+		private IndexCompletionService $indexCompletionService,
+	) {
+		parent::__construct($timeFactory);
+	}
+
+	/**
+	 * @param array{storage_id:int, root_id:int, last_file_id:int|null} $argument
+	 * @return void
+	 */
+	protected function run($argument): void {
+		$storageId = $argument['storage_id'];
+		$rootId = $argument['root_id'];
+		$lastFileId = ($argument['last_file_id'] ?? null) === null ? 0 : $argument['last_file_id'];
+
+		// Remove current iteration
+		$this->jobList->remove(self::class, $argument);
+
+		$mountFilesCount = 0;
+		$lastFileIdSeen = $lastFileId;
+		foreach ($this->storageService->getFilesInMount($storageId, $rootId, $lastFileId, self::BATCH_SIZE) as $fileId) {
+			$lastFileIdSeen = $fileId;
+			$mountFilesCount++;
+
+			$node = $this->rootFolder->getFirstNodeById($fileId);
+			if ($node === null) {
+				continue;
+			}
+
+			if (!$this->fsEventService->hasAiKnowledgeTag($node)) {
+				$this->fsEventService->onDelete($node, false);
+			}
+		}
+
+		if ($mountFilesCount > 0) {
+			// Schedule next batch
+			$this->jobList->scheduleAfter(self::class, $this->time->getTime() + self::JOB_INTERVAL, [
+				'storage_id' => $storageId,
+				'root_id' => $rootId,
+				'last_file_id' => $lastFileIdSeen,
+			]);
+		} else {
+			$this->logger->info('[UntaggedCleanupCrawlJob] Finished mount storage_id=' . $storageId . ' root_id=' . $rootId);
+			$this->indexCompletionService->checkAndMarkComplete();
+		}
+	}
+}

--- a/lib/BackgroundJobs/UntaggedCleanupSchedulerJob.php
+++ b/lib/BackgroundJobs/UntaggedCleanupSchedulerJob.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ContextChat\BackgroundJobs;
+
+use OCA\ContextChat\Logger;
+use OCA\ContextChat\Service\StorageService;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\QueuedJob;
+
+/**
+ * Discovers all mounts and schedules an UntaggedCleanupCrawlJob for each,
+ * mirroring SchedulerJob's shape.
+ */
+class UntaggedCleanupSchedulerJob extends QueuedJob {
+	public function __construct(
+		ITimeFactory $timeFactory,
+		private Logger $logger,
+		private IJobList $jobList,
+		private StorageService $storageService,
+		private IAppConfig $appConfig,
+	) {
+		parent::__construct($timeFactory);
+	}
+
+	protected function run($argument): void {
+		// Mirror SchedulerJob: a fresh cleanup run means the initial-indexing
+		// status is no longer settled until this run finishes.
+		$this->appConfig->setAppValueInt('last_indexed_time', 0, lazy: true);
+		foreach ($this->storageService->getMounts() as $mount) {
+			$this->logger->debug('[UntaggedCleanupSchedulerJob] Scheduling cleanup storage_id=' . $mount['storage_id'] . ' root_id=' . $mount['root_id']);
+			$this->jobList->add(UntaggedCleanupCrawlJob::class, [
+				'storage_id' => $mount['storage_id'],
+				'root_id' => $mount['root_id'],
+				'last_file_id' => 0,
+			]);
+		}
+		$this->jobList->remove(self::class);
+	}
+}

--- a/lib/Command/CleanupUntagged.php
+++ b/lib/Command/CleanupUntagged.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ContextChat\Command;
+
+use OCA\ContextChat\BackgroundJobs\UntaggedCleanupSchedulerJob;
+use OCP\BackgroundJob\IJobList;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Schedule removal from the index of all files that do not have the
+ * "AI knowledge" tag. Used when switching to the tag-only indexing mode.
+ */
+class CleanupUntagged extends Command {
+	public function __construct(
+		private IJobList $jobList,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this->setName('context_chat:cleanup-untagged')
+			->setDescription('Schedule removal from the index of all files that do not have the "AI knowledge" tag.');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		if ($this->jobList->has(UntaggedCleanupSchedulerJob::class, null)) {
+			$output->writeln('<comment>A cleanup is already scheduled; nothing to do.</comment>');
+			return 0;
+		}
+		$this->jobList->add(UntaggedCleanupSchedulerJob::class);
+		$output->writeln('<info>Scheduled removal of untagged files from the index.</info>');
+		return 0;
+	}
+}

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -7,10 +7,14 @@
 
 namespace OCA\ContextChat\Controller;
 
+use OCA\ContextChat\BackgroundJobs\SchedulerJob;
+use OCA\ContextChat\BackgroundJobs\UntaggedCleanupSchedulerJob;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Services\IAppConfig;
+use OCP\BackgroundJob\IJobList;
+use OCP\IAppConfig as ICoreAppConfig;
 use OCP\IRequest;
 use OCP\PreConditionNotMetException;
 
@@ -20,6 +24,8 @@ class ConfigController extends Controller {
 		string $appName,
 		IRequest $request,
 		private IAppConfig $appConfig,
+		private IJobList $jobList,
+		private ICoreAppConfig $coreAppConfig,
 		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
@@ -50,9 +56,21 @@ class ConfigController extends Controller {
 	 * @return DataResponse
 	 */
 	public function setAdminConfig(array $values): DataResponse {
+		if (isset($values['index_mode'])) {
+			$oldMode = $this->appConfig->getAppValueString('index_mode', 'all', lazy: true);
+			$newMode = $values['index_mode'];
+			if ($newMode !== $oldMode) {
+				if ($newMode === 'tag_only') {
+					$this->jobList->add(UntaggedCleanupSchedulerJob::class);
+				} else {
+					$this->jobList->add(SchedulerJob::class);
+				}
+			}
+		}
 		foreach ($values as $key => $value) {
 			$this->appConfig->setAppValueString($key, $value, lazy: true);
 		}
+		$this->coreAppConfig->clearCache();
 		return new DataResponse(1);
 	}
 }

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -49,6 +49,21 @@ class ConfigController extends Controller {
 		return new DataResponse(1);
 	}
 
+	private function handleIndexModeChange(array $values): void {
+		if (!isset($values['index_mode'])) {
+			return;
+		}
+		$oldMode = $this->appConfig->getAppValueString('index_mode', 'all', lazy: true);
+		$newMode = $values['index_mode'];
+		if ($newMode === $oldMode) {
+			return;
+		}
+		if ($newMode === 'tag_only') {
+			$this->jobList->add(UntaggedCleanupSchedulerJob::class);
+		} else {
+			$this->jobList->add(SchedulerJob::class);
+		}
+	}
 	/**
 	 * Set admin config values
 	 *
@@ -56,17 +71,7 @@ class ConfigController extends Controller {
 	 * @return DataResponse
 	 */
 	public function setAdminConfig(array $values): DataResponse {
-		if (isset($values['index_mode'])) {
-			$oldMode = $this->appConfig->getAppValueString('index_mode', 'all', lazy: true);
-			$newMode = $values['index_mode'];
-			if ($newMode !== $oldMode) {
-				if ($newMode === 'tag_only') {
-					$this->jobList->add(UntaggedCleanupSchedulerJob::class);
-				} else {
-					$this->jobList->add(SchedulerJob::class);
-				}
-			}
-		}
+		$this->handleIndexModeChange($values);
 		foreach ($values as $key => $value) {
 			$this->appConfig->setAppValueString($key, $value, lazy: true);
 		}

--- a/lib/Controller/QueueController.php
+++ b/lib/Controller/QueueController.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 
 namespace OCA\ContextChat\Controller;
 
-use OCA\ContextChat\BackgroundJobs\StorageCrawlJob;
 use OCA\ContextChat\Db\QueueActionMapper;
 use OCA\ContextChat\Db\QueueContentItem;
 use OCA\ContextChat\Db\QueueContentItemMapper;
 use OCA\ContextChat\Db\QueueFile;
 use OCA\ContextChat\Db\QueueMapper;
+use OCA\ContextChat\Service\IndexCompletionService;
 use OCA\ContextChat\Service\ProviderConfigService;
 use OCA\ContextChat\Service\QueueService;
 use OCA\ContextChat\Service\StorageService;
@@ -39,7 +39,6 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
 class QueueController extends OCSController {
-	private const INDEX_COMPLETION_THRESHOLD = 0.02; // 2%
 
 	public function __construct(
 		string $appName,
@@ -51,6 +50,7 @@ class QueueController extends OCSController {
 		private IJobList $jobList,
 		private ITimeFactory $timeFactory,
 		private QueueMapper $queueMapper,
+		private IndexCompletionService $indexCompletionService,
 		string $corsMethods = 'PUT, POST, GET, DELETE, PATCH',
 		string $corsAllowedHeaders = 'Authorization, Content-Type, Accept, OCS-APIRequest',
 		int $corsMaxAge = 1728000,
@@ -112,6 +112,7 @@ class QueueController extends OCSController {
 			$n = $maxN;
 		}
 		try {
+			$this->indexCompletionService->checkAndMarkComplete();
 			$files = [];
 			while (count($files) < $n) {
 				$limit = $n - count($files);
@@ -181,7 +182,7 @@ class QueueController extends OCSController {
 		}
 
 		try {
-			$this->setInitialIndexCompletion();
+			$this->indexCompletionService->checkAndMarkComplete();
 		} catch (\Exception $e) {
 			$this->logger->warning('Could not check for initial index completion', ['exception' => $e]);
 		}
@@ -326,76 +327,5 @@ class QueueController extends OCSController {
 			$providerKey,
 			strlen($document->getContent()),
 		);
-	}
-
-	/**
-	 * @template T of \OCP\BackgroundJob\Job
-	 * @psalm-param T::class $jobClass
-	 */
-	public function getJobCount(string $jobClass): int {
-		$countByClass = array_values(array_filter($this->jobList->countByClass(), fn ($row) => $row['class'] == $jobClass));
-		$jobCount = count($countByClass) > 0 ? $countByClass[0]['count'] : 0;
-		return $jobCount;
-	}
-
-	private function setInitialIndexCompletion(): void {
-		if ($this->appConfig->getAppValueInt('last_indexed_time', 0, lazy: true) !== 0) {
-			return;
-		}
-
-		try {
-			$crawlJobCount = $this->getJobCount(StorageCrawlJob::class);
-			if ($crawlJobCount > 0) {
-				$this->logger->debug('StorageCrawlJob\'s still scheduled for execution, intial indexing has not completed.');
-				return;
-			}
-		} catch (\Exception $e) {
-			$this->logger->warning('Could not get count of scheduled StorageCrawlJob jobs', ['exception' => $e]);
-			return;
-		}
-
-		try {
-			$lastEnqueuedDbId = $this->appConfig->getAppValueInt('last_enqueued_db_id', -1, lazy: true);
-			if ($lastEnqueuedDbId !== -1) {
-				$initiallyQueuedFilesExist = $this->queueMapper->existsQueueItemsUpToDbId($lastEnqueuedDbId);
-				if ($initiallyQueuedFilesExist) {
-					$this->logger->debug('Initially queued files still in the queue, intial indexing has not completed.');
-					return;
-				}
-				$this->logger->info('Initial index completion detected, setting last indexed time');
-				$this->appConfig->setAppValueInt('last_indexed_time', $this->timeFactory->getTime(), lazy: true);
-				return;
-			}
-		} catch (\Exception $e) {
-			$this->logger->warning('Could not get last enqueued file\'s DB id', ['exception' => $e]);
-		}
-
-		// last enqueued file's ID could not be retrieved, falling back to file counting method
-		try {
-			$queuedNewFilesCount = $this->queueService->countNewFiles();
-			$eligibleFilesCount = $this->storageService->countFiles();
-			// if the new files in the queue are less than 2% of the total eligible files, we consider the
-			// initial indexing complete this allows for some margin of error in case some files were
-			// added while we were indexing but still ensures that we have indexed the vast majority of
-			// files at least once
-			if (self::withinThreshold($queuedNewFilesCount, $eligibleFilesCount)) {
-				$this->logger->info('Initial index completion detected, setting last indexed time');
-				$this->appConfig->setAppValueInt('last_indexed_time', $this->timeFactory->getTime(), lazy: true);
-				return;
-			}
-		} catch (\OCP\DB\Exception $e) {
-			$this->logger->warning('Could not count queued new files or total eligible files', ['exception' => $e]);
-			return;
-		}
-
-		// we are still indexing files that were never indexed before.
-		$this->logger->debug('Initial indexing not completed yet', [
-			'queuedNewFilesCount' => $queuedNewFilesCount,
-			'eligibleFilesCount' => $eligibleFilesCount,
-		]);
-	}
-
-	private static function withinThreshold(int $current, int $total, float $threshold = self::INDEX_COMPLETION_THRESHOLD): bool {
-		return ((float)($total - $current) / (float)$total) < $threshold;
 	}
 }

--- a/lib/Service/FsEventService.php
+++ b/lib/Service/FsEventService.php
@@ -10,12 +10,16 @@ namespace OCA\ContextChat\Service;
 use OCA\ContextChat\AppInfo\Application;
 use OCA\ContextChat\Db\QueueFile;
 use OCA\ContextChat\Logger;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\DB\Exception;
 use OCP\Files\Folder;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\SystemTag\ISystemTagManager;
+use OCP\SystemTag\ISystemTagObjectMapper;
+use OCP\SystemTag\TagNotFoundException;
 
 class FsEventService {
 
@@ -25,6 +29,9 @@ class FsEventService {
 		private ActionScheduler $actionService,
 		private StorageService $storageService,
 		private IRootFolder $rootFolder,
+		private ISystemTagManager $tagManager,
+		private IAppConfig $appConfig,
+		private ISystemTagObjectMapper $tagMapper,
 	) {
 
 	}
@@ -99,6 +106,9 @@ class FsEventService {
 		if (!$this->allowedPath($node)) {
 			return;
 		}
+		if (!$this->hasAiKnowledgeTag($node)) {
+			return;
+		}
 		if ($node instanceof Folder) {
 			if (!$recurse) {
 				return;
@@ -130,6 +140,46 @@ class FsEventService {
 				$this->logger->error('Failed to add file to queue', ['exception' => $e]);
 			}
 		}
+	}
+
+	public function hasAiKnowledgeTag(Node $node): bool {
+		$mode = $this->appConfig->getAppValueString('index_mode', 'all', lazy: true);
+		if ($mode !== 'tag_only') {
+			// Default mode: index everything, as before.
+			return true;
+		}
+
+		try {
+			$tag = $this->tagManager->getTag('AI knowledge', true, true);
+		} catch (TagNotFoundException $e) {
+			return false;
+		}
+
+		$current = $node;
+		$depth = 0;
+		$maxDepth = 50;
+		while ($current !== null && $depth < $maxDepth) {
+			try {
+				if ($this->tagMapper->haveTag((string)$current->getId(), 'files', $tag->getId())) {
+					return true;
+				}
+			} catch (TagNotFoundException|InvalidPathException|NotFoundException $e) {
+				return false;
+			}
+
+			if ($current->getPath() === '/' || $current->getInternalPath() === '') {
+				break;
+			}
+
+			try {
+				$current = $current->getParent();
+			} catch (\Throwable $e) {
+				break;
+			}
+			$depth++;
+		}
+
+		return false;
 	}
 
 	private function allowedMimeType(Node $file): bool {

--- a/lib/Service/IndexCompletionService.php
+++ b/lib/Service/IndexCompletionService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ContextChat\Service;
+
+use OCA\ContextChat\BackgroundJobs\StorageCrawlJob;
+use OCA\ContextChat\BackgroundJobs\UntaggedCleanupCrawlJob;
+use OCA\ContextChat\Db\QueueActionMapper;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Checks whether the initial full indexing run has completed, and marks it
+ * as such (setting app config 'last_indexed_time'). Extracted from
+ * QueueController so that BOTH the normal indexing flow (via QueueController)
+ * AND the tag-based cleanup flow (via UntaggedCleanupCrawlJob) can trigger
+ * this check when they finish their own work, instead of relying solely on
+ * the document-queue DELETE endpoint being called.
+ */
+class IndexCompletionService {
+	public function __construct(
+		private LoggerInterface $logger,
+		private IAppConfig $appConfig,
+		private QueueService $queueService,
+		private QueueActionMapper $queueActionMapper,
+		private IJobList $jobList,
+		private ITimeFactory $timeFactory,
+	) {
+	}
+
+	/**
+	 * @template T of \OCP\BackgroundJob\Job
+	 * @psalm-param T::class $jobClass
+	 */
+	private function getJobCount(string $jobClass): int {
+		$countByClass = array_values(array_filter($this->jobList->countByClass(), fn ($row) => $row['class'] == $jobClass));
+		return count($countByClass) > 0 ? $countByClass[0]['count'] : 0;
+	}
+
+	public function checkAndMarkComplete(): void {
+		if ($this->appConfig->getAppValueInt('last_indexed_time', 0, lazy: true) !== 0) {
+			return;
+		}
+		try {
+			$crawlJobCount = $this->getJobCount(StorageCrawlJob::class) + $this->getJobCount(UntaggedCleanupCrawlJob::class);
+			if ($crawlJobCount > 0) {
+				$this->logger->debug('A crawl job (indexing or tag cleanup) is still scheduled for execution, intial indexing has not completed.');
+				return;
+			}
+		} catch (\Exception $e) {
+			$this->logger->warning('Could not get count of scheduled StorageCrawlJob jobs', ['exception' => $e]);
+			return;
+		}
+		try {
+			$queuedFilesCount = $this->queueService->count();
+			if ($queuedFilesCount > 0) {
+				$this->logger->debug('Files still in queue, intial indexing has not completed.', ['count' => $queuedFilesCount]);
+				return;
+			}
+			$pendingActionsCount = $this->queueActionMapper->count();
+			if ($pendingActionsCount > 0) {
+				$this->logger->debug('Actions still pending (e.g. tag-based deletions), intial indexing has not completed.', ['count' => $pendingActionsCount]);
+				return;
+			}
+			$this->logger->info('Initial index completion detected (live state check), setting last indexed time');
+			$this->appConfig->setAppValueInt('last_indexed_time', $this->timeFactory->getTime(), lazy: true);
+		} catch (\OCP\DB\Exception $e) {
+			$this->logger->warning('Could not count queue items', ['exception' => $e]);
+		}
+	}
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -8,6 +8,7 @@ namespace OCA\ContextChat\Settings;
 
 use OCA\ContextChat\Service\StatisticsService;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Settings\ISettings;
 
@@ -15,6 +16,7 @@ class AdminSettings implements ISettings {
 	public function __construct(
 		private IInitialState $initialState,
 		private StatisticsService $statisticsService,
+		private IAppConfig $appConfig,
 	) {
 	}
 
@@ -24,6 +26,8 @@ class AdminSettings implements ISettings {
 	public function getForm(): TemplateResponse {
 		$stats = $this->statisticsService->getStatistics();
 		$this->initialState->provideInitialState('stats', $stats);
+		$indexMode = $this->appConfig->getAppValueString('index_mode', 'all', lazy: true);
+		$this->initialState->provideInitialState('index_mode', $indexMode);
 		return new TemplateResponse('context_chat', 'admin');
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "1.0.0",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
+				"@nextcloud/axios": "2.5.1",
+				"@nextcloud/dialogs": "7.3.0",
 				"@nextcloud/initial-state": "^2.2.0",
 				"@nextcloud/router": "^3.0.1",
 				"@nextcloud/vue": "^9.0.0-rc.9",
@@ -361,18 +363,18 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -421,12 +423,12 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-			"integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+			"integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.4"
+				"@babel/types": "^7.29.8"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1640,13 +1642,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-			"integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+			"version": "7.29.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+			"integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1657,7 +1659,6 @@
 			"resolved": "https://registry.npmjs.org/@buttercup/fetch/-/fetch-0.2.1.tgz",
 			"integrity": "sha512-sCgECOx8wiqY8NN1xN22BqqKzXYIG2AicNLlakOAI4f0WgyLVUbAigMf8CZhBtJxdudTcB1gD5lciqi44jwJvg==",
 			"license": "MIT",
-			"optional": true,
 			"optionalDependencies": {
 				"node-fetch": "^3.3.0"
 			}
@@ -2179,6 +2180,23 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/sunos-x64": {
 			"version": "0.25.5",
 			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
@@ -2382,28 +2400,28 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-			"integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+			"integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+			"integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.3",
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/core": "^1.8.0",
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+			"integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
 			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -2477,11 +2495,19 @@
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
 			"integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
@@ -2489,9 +2515,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -2506,9 +2530,7 @@
 			"version": "0.3.29",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
 			"integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2550,6 +2572,12 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
 			}
+		},
+		"node_modules/@mdi/js": {
+			"version": "7.4.47",
+			"resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
+			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@microsoft/api-extractor": {
 			"version": "7.52.8",
@@ -2721,13 +2749,14 @@
 			}
 		},
 		"node_modules/@nextcloud/auth": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.2.tgz",
-			"integrity": "sha512-1dr+Xhvg2QtsFC23KFXJSkU524EVgI/+WFBGTZ8tFa+9hmcZ3CqZIHjtXm3KxUvezwAY5023Ml0n2vpdYkpBXQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.6.0.tgz",
+			"integrity": "sha512-VkT87+9UqpPi7O36bVEE4/MxWF8d90VQcuMlvKltsZyLSLkEGrPXgowtD75Y54k60/8SR6mXbeqBwapi8dDUbA==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/browser-storage": "^0.4.0",
-				"@nextcloud/event-bus": "^3.3.2"
+				"@nextcloud/browser-storage": "^0.5.0",
+				"@nextcloud/event-bus": "^3.3.3",
+				"@nextcloud/router": "^3.1.0"
 			},
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
@@ -2765,16 +2794,12 @@
 			}
 		},
 		"node_modules/@nextcloud/browser-storage": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
-			"integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
+			"integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA==",
 			"license": "GPL-3.0-or-later",
-			"dependencies": {
-				"core-js": "3.37.0"
-			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^24 || ^22 || ^20"
 			}
 		},
 		"node_modules/@nextcloud/browserslist-config": {
@@ -2789,16 +2814,135 @@
 			}
 		},
 		"node_modules/@nextcloud/capabilities": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.2.0.tgz",
-			"integrity": "sha512-L1NQtOfHWzkfj0Ple1MEJt6HmOHWAi3y4qs+OnwSWexqJT0DtXTVPyRxi7ADyITwRxS5H9R/HMl6USAj4Nr1nQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.2.1.tgz",
+			"integrity": "sha512-snZ0/910zzwN6PDsIlx2Uvktr1S5x0ClhDUnfPlCj7ntNvECzuVHNY5wzby22LIkc+9ZjaDKtCwuCt2ye+9p/Q==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/initial-state": "^2.1.0"
+				"@nextcloud/initial-state": "^3.0.0"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/capabilities/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-7.3.0.tgz",
+			"integrity": "sha512-pFuM10Dkvip+wSBaElcbSAN7Jynp41HJUh5kndRYpJipYl0SpNfjIe32+uNfOI43/tln4ScTlrfjIX6cK+3uHg==",
+			"license": "AGPL-3.0-or-later",
+			"dependencies": {
+				"@mdi/js": "^7.4.47",
+				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/axios": "^2.5.2",
+				"@nextcloud/browser-storage": "^0.5.0",
+				"@nextcloud/event-bus": "^3.3.3",
+				"@nextcloud/files": "^4.0.0",
+				"@nextcloud/initial-state": "^3.0.0",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/paths": "^3.0.0",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.4.0",
+				"@nextcloud/vue": "^9.5.0",
+				"@types/toastify-js": "^1.12.4",
+				"@vueuse/core": "^14.2.1",
+				"p-queue": "^9.0.1",
+				"toastify-js": "^1.12.0",
+				"vue": "^3.5.28",
+				"webdav": "^5.8.0"
+			},
+			"engines": {
+				"node": "^20 || ^22 || ^24"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/axios": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.6.0.tgz",
+			"integrity": "sha512-ehcIgyora8DAJ+STG6iFI4e+ufPVFrIA6o0FgMKeKdfyaxRJ9UM7L+n7V+rc/qv8sDiWC/hWIKwFtLw2W5yE4Q==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/auth": "^2.6.0",
+				"axios": "^1.15.0"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
+			"integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
+			"license": "AGPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/capabilities": "^1.2.1",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/logger": "^3.0.3",
+				"@nextcloud/paths": "^3.0.0",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.3.0",
+				"is-svg": "^6.1.0",
+				"typescript-event-target": "^1.1.2",
+				"webdav": "^5.9.0"
+			},
+			"engines": {
+				"node": "^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files/node_modules/@nextcloud/files": {
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+			"integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+			"license": "AGPL-3.0-or-later",
+			"optional": true,
+			"dependencies": {
+				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/capabilities": "^1.2.1",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/logger": "^3.0.3",
+				"@nextcloud/paths": "^3.0.0",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.3.0",
+				"cancelable-promise": "^4.3.1",
+				"is-svg": "^6.1.0",
+				"typescript-event-target": "^1.1.1",
+				"webdav": "^5.8.0"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/files/node_modules/@nextcloud/sharing": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
+			"integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/initial-state": "^3.0.0",
+				"is-svg": "^6.1.0"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			},
+			"optionalDependencies": {
+				"@nextcloud/files": "^3.12.0"
+			}
+		},
+		"node_modules/@nextcloud/dialogs/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/eslint-config": {
@@ -2863,17 +3007,16 @@
 			}
 		},
 		"node_modules/@nextcloud/event-bus": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.2.tgz",
-			"integrity": "sha512-1Qfs6i7Tz2qd1A33NpBQOt810ydHIRjhyXMFwSEkYX2yUI80lAk/sWO8HIB2Fqp+iffhyviPPcQYoytMDRyDNw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.3.3.tgz",
+			"integrity": "sha512-zIfvKmUGkXpVzRKoXrcO9hkoiKDm65fqNxy/XIbIxrQhZByPq3gDkjBpnu3V5Gs8JdYwa73R8DjzV9oH8HYhIg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@types/semver": "^7.5.8",
-				"semver": "^7.6.3"
+				"@types/semver": "^7.7.0",
+				"semver": "^7.7.2"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20 || ^22 || ^24"
 			}
 		},
 		"node_modules/@nextcloud/event-bus/node_modules/semver": {
@@ -2889,21 +3032,21 @@
 			}
 		},
 		"node_modules/@nextcloud/files": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.0.tgz",
-			"integrity": "sha512-LVZklgooZzBj2jkbPRZO4jnnvW5+RvOn7wN5weyOZltF6i2wVMbg1Y/Czl2pi/UNMjUm5ENqc0j7FgxMBo8bwA==",
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+			"integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
 			"license": "AGPL-3.0-or-later",
 			"optional": true,
 			"dependencies": {
-				"@nextcloud/auth": "^2.5.1",
-				"@nextcloud/capabilities": "^1.2.0",
-				"@nextcloud/l10n": "^3.3.0",
-				"@nextcloud/logger": "^3.0.2",
-				"@nextcloud/paths": "^2.2.1",
-				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/sharing": "^0.2.4",
+				"@nextcloud/auth": "^2.5.3",
+				"@nextcloud/capabilities": "^1.2.1",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/logger": "^3.0.3",
+				"@nextcloud/paths": "^3.0.0",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.3.0",
 				"cancelable-promise": "^4.3.1",
-				"is-svg": "^6.0.0",
+				"is-svg": "^6.1.0",
 				"typescript-event-target": "^1.1.1",
 				"webdav": "^5.8.0"
 			},
@@ -2911,17 +3054,31 @@
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
+		"node_modules/@nextcloud/files/node_modules/@nextcloud/initial-state": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+			"integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+			"license": "GPL-3.0-or-later",
+			"optional": true,
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
 		"node_modules/@nextcloud/files/node_modules/@nextcloud/sharing": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.2.5.tgz",
-			"integrity": "sha512-B3K5Dq9b5dexDA5n3AAuCF69Huwhrpw0J72fsVXV4KpPdImjhVPlExAv5o70AoXa+OqN4Rwn6gqJw+3ED892zg==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
+			"integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
 			"license": "GPL-3.0-or-later",
 			"optional": true,
 			"dependencies": {
-				"@nextcloud/initial-state": "^2.2.0"
+				"@nextcloud/initial-state": "^3.0.0",
+				"is-svg": "^6.1.0"
 			},
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			},
+			"optionalDependencies": {
+				"@nextcloud/files": "^3.12.0"
 			}
 		},
 		"node_modules/@nextcloud/initial-state": {
@@ -2935,9 +3092,9 @@
 			}
 		},
 		"node_modules/@nextcloud/l10n": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.0.tgz",
-			"integrity": "sha512-K4UBSl0Ou6sXXLxyjuhktRf2FyTCjyvHxJyBLmS2z3YEYcRkpf8ib3XneRwEQIEpzBPQjul2/ZdFlt7umd8Gaw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.1.tgz",
+			"integrity": "sha512-aTFinTcKiK2gEXwLgutXekpZZ8/v/4QiC8C3QCLH5m0o+WtxsBC+fqV142ebC/rfDnzCLhY4ZtswSu8bFbZocg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/router": "^3.0.1",
@@ -2951,46 +3108,42 @@
 			}
 		},
 		"node_modules/@nextcloud/logger": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.2.tgz",
-			"integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.3.tgz",
+			"integrity": "sha512-TcbVRL4/O5ffI1RXFmQAFD3gwwT15AAdr1770x+RNqVvfBdoGVyhzOwCIyA5Vfc3fA1iJXFa+rE6buJZSoqlcw==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/auth": "^2.3.0"
+				"@nextcloud/auth": "^2.5.3"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/paths": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.2.1.tgz",
-			"integrity": "sha512-M3ShLjrxR7B48eKThLMoqbxTqTKyQXcwf9TgeXQGbCIhiHoXU6as5j8l5qNv/uZlANokVdowpuWHBi3b2+YNNA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-3.1.0.tgz",
+			"integrity": "sha512-vtFYA/kthaUDzu6KejTOL1OwnOy7/yynq5zdB/UBpYacAWjUX5Ddh4OMWx3rEavkBJ9/QGhrFryNJLjNfe8OQA==",
 			"license": "GPL-3.0-or-later",
-			"optional": true,
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/router": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.1.tgz",
-			"integrity": "sha512-Ci/uD3x8OKHdxSqXL6gRJ+mGJOEXjeiHjj7hqsZqVTsT7kOrCjDf0/J8z5RyLlokKZ0IpSe+hGxgi3YB7Gpw3Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.1.0.tgz",
+			"integrity": "sha512-e4dkIaxRSwdZJlZFpn9x03QgBn/Sa2hN1hp/BA7+AbzykmSAlKuWfdmX8j/8ewrLpQwYmZR23IZO9XwpJXq2Uw==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"@nextcloud/typings": "^1.7.0"
+				"@nextcloud/typings": "^1.10.0"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/sharing": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
-			"integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.4.0.tgz",
+			"integrity": "sha512-1hUNyc7uJdBpnimOnEshJjEtAPAjzDYVl6qmWqF5ZxoN9wOvbExw0QjX3xFIbHbX2dmvbRNLBj0RzLzipmZyeg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/initial-state": "^3.0.0",
@@ -3000,7 +3153,7 @@
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			},
 			"optionalDependencies": {
-				"@nextcloud/files": "^3.12.0"
+				"@nextcloud/files": "^3.12.2 || ^4.0.0"
 			}
 		},
 		"node_modules/@nextcloud/sharing/node_modules/@nextcloud/initial-state": {
@@ -3031,29 +3184,16 @@
 				"stylelint-config-recommended-vue": "^1.5.0"
 			}
 		},
-		"node_modules/@nextcloud/timezones": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-1.0.0.tgz",
-			"integrity": "sha512-9b7Wms2mzB4RAltf8s9dY40PcU5ova5QjQJw1Gty35e54alKyx33BqUOy4gEbkzmYSrW4aZcLcMrOO5Bj2eIzg==",
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"ical.js": "^2.1.0"
-			},
-			"engines": {
-				"node": "^20 || ^22"
-			}
-		},
 		"node_modules/@nextcloud/typings": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.1.tgz",
-			"integrity": "sha512-i0l/L5gKW8EACbXHVxXM6wn3sUhY2qmnL2OijppzU4dENC7/hqySMQDer7/+cJbNSNG7uHF/Z+9JmHtDfRfuGg==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.10.0.tgz",
+			"integrity": "sha512-SMC42rDjOH3SspPTLMZRv76ZliHpj2JJkF8pGLP8l1QrVTZxE47Qz5qeKmbj2VL+dRv2e/NgixlAFmzVnxkhqg==",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@types/jquery": "3.5.16"
 			},
 			"engines": {
-				"node": "^20.0.0",
-				"npm": "^10.0.0"
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/vite-config": {
@@ -3087,38 +3227,38 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "9.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.9.tgz",
-			"integrity": "sha512-rrM0KmRMGK2u1y9VZNJwVA7IzzU1OMnPkqU5ii9j07F5uOjy4J97/Bu71maQ19nfZA8tFe6INKHuX5AgOPYkbg==",
+			"version": "9.11.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.11.0.tgz",
+			"integrity": "sha512-LRsyU9Mxs0b2xWqbxygps8O7/i1z4QhNQD9/QDni+VqFY3V0N95mAgmKJm6vfoFuxTAMXERp9bjqFn3UV542gw==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@ckpack/vue-color": "^1.6.0",
-				"@floating-ui/dom": "^1.7.4",
-				"@nextcloud/auth": "^2.5.2",
-				"@nextcloud/axios": "^2.5.1",
-				"@nextcloud/browser-storage": "^0.4.0",
-				"@nextcloud/capabilities": "^1.2.0",
-				"@nextcloud/event-bus": "^3.3.2",
+				"@floating-ui/dom": "^1.8.0",
+				"@nextcloud/auth": "^2.6.0",
+				"@nextcloud/axios": "^2.6.0",
+				"@nextcloud/browser-storage": "^0.5.0",
+				"@nextcloud/capabilities": "^1.2.1",
+				"@nextcloud/event-bus": "^3.3.3",
 				"@nextcloud/initial-state": "^3.0.0",
-				"@nextcloud/l10n": "^3.4.0",
-				"@nextcloud/logger": "^3.0.2",
-				"@nextcloud/router": "^3.0.1",
-				"@nextcloud/sharing": "^0.3.0",
-				"@nextcloud/timezones": "^1.0.0",
-				"@vuepic/vue-datepicker": "^11.0.2",
-				"@vueuse/components": "^13.9.0",
-				"@vueuse/core": "^13.9.0",
+				"@nextcloud/l10n": "^3.4.1",
+				"@nextcloud/logger": "^3.0.3",
+				"@nextcloud/router": "^3.1.0",
+				"@nextcloud/sharing": "^0.4.0",
+				"@nextcloud/vue-select": "^4.1.0",
+				"@vuepic/vue-datepicker": "^11.0.3",
+				"@vueuse/components": "^14.4.0",
+				"@vueuse/core": "^14.4.0",
 				"blurhash": "^2.0.5",
 				"clone": "^2.1.2",
-				"crypto-browserify": "^3.12.1",
-				"debounce": "^2.2.0",
-				"dompurify": "^3.2.6",
+				"debounce": "^3.0.0",
+				"dompurify": "^3.4.14",
 				"emoji-mart-vue-fast": "^15.0.5",
 				"escape-html": "^1.0.3",
 				"floating-vue": "^5.2.2",
-				"focus-trap": "^7.6.5",
-				"linkifyjs": "^4.3.2",
-				"p-queue": "^8.1.1",
+				"focus-trap": "^8.2.2",
+				"linkifyjs": "^4.3.3",
+				"mdast-util-to-string": "^4.0.0",
+				"p-queue": "^9.3.3",
 				"rehype-external-links": "^3.0.0",
 				"rehype-highlight": "^7.0.2",
 				"rehype-react": "^8.0.0",
@@ -3128,17 +3268,467 @@
 				"remark-unlink-protocols": "^1.0.0",
 				"splitpanes": "^4.0.4",
 				"striptags": "^3.2.0",
-				"tabbable": "^6.2.0",
+				"tabbable": "^6.4.0",
 				"tributejs": "^5.1.3",
+				"ts-md5": "^2.0.1",
 				"unified": "^11.0.5",
 				"unist-builder": "^4.0.0",
-				"unist-util-visit": "^5.0.0",
+				"unist-util-visit-parents": "^6.0.2",
 				"vue": "^3.5.18",
-				"vue-router": "^4.5.1",
-				"vue-select": "^4.0.0-beta.6"
+				"vue-router": "^5.2.0"
 			},
 			"engines": {
 				"node": "^20.11.0 || ^22 || ^24"
+			}
+		},
+		"node_modules/@nextcloud/vue-select": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-4.1.0.tgz",
+			"integrity": "sha512-jQIu4XuUAuJr6qL/IKa63h3Vv/4OrP9latl2E6kqtffwLBV+qMSU4Gm+vsOfyqBbBSY4i3eeMfdyJi14O1Yqbg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^22 || ^24"
+			},
+			"peerDependencies": {
+				"vue": "^3"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/android-arm": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/android-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/axios": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.6.0.tgz",
+			"integrity": "sha512-ehcIgyora8DAJ+STG6iFI4e+ufPVFrIA6o0FgMKeKdfyaxRJ9UM7L+n7V+rc/qv8sDiWC/hWIKwFtLw2W5yE4Q==",
+			"license": "GPL-3.0-or-later",
+			"dependencies": {
+				"@nextcloud/auth": "^2.6.0",
+				"axios": "^1.15.0"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
 			}
 		},
 		"node_modules/@nextcloud/vue/node_modules/@nextcloud/initial-state": {
@@ -3148,6 +3738,213 @@
 			"license": "GPL-3.0-or-later",
 			"engines": {
 				"node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/@vue/devtools-api": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.2.1.tgz",
+			"integrity": "sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==",
+			"license": "MIT",
+			"dependencies": {
+				"@vue/devtools-kit": "^8.2.1"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/chokidar": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/esbuild": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.2",
+				"@esbuild/android-arm": "0.28.2",
+				"@esbuild/android-arm64": "0.28.2",
+				"@esbuild/android-x64": "0.28.2",
+				"@esbuild/darwin-arm64": "0.28.2",
+				"@esbuild/darwin-x64": "0.28.2",
+				"@esbuild/freebsd-arm64": "0.28.2",
+				"@esbuild/freebsd-x64": "0.28.2",
+				"@esbuild/linux-arm": "0.28.2",
+				"@esbuild/linux-arm64": "0.28.2",
+				"@esbuild/linux-ia32": "0.28.2",
+				"@esbuild/linux-loong64": "0.28.2",
+				"@esbuild/linux-mips64el": "0.28.2",
+				"@esbuild/linux-ppc64": "0.28.2",
+				"@esbuild/linux-riscv64": "0.28.2",
+				"@esbuild/linux-s390x": "0.28.2",
+				"@esbuild/linux-x64": "0.28.2",
+				"@esbuild/netbsd-arm64": "0.28.2",
+				"@esbuild/netbsd-x64": "0.28.2",
+				"@esbuild/openbsd-arm64": "0.28.2",
+				"@esbuild/openbsd-x64": "0.28.2",
+				"@esbuild/openharmony-arm64": "0.28.2",
+				"@esbuild/sunos-x64": "0.28.2",
+				"@esbuild/win32-arm64": "0.28.2",
+				"@esbuild/win32-ia32": "0.28.2",
+				"@esbuild/win32-x64": "0.28.2"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/readdirp": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+			"integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/vite": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+			"integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"lightningcss": "^1.33.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.26",
+				"rolldown": "~1.2.4",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.4.0 || ^0.5.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@nextcloud/vue/node_modules/vue-router": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.3.0.tgz",
+			"integrity": "sha512-a2PBXX9yfkS58JzSJALUffgDa09lEzKmCcEnLaepoIr88L+9hEnsgEQkcadJGID+vtHa0gFpVo064zmylA9fcg==",
+			"license": "MIT",
+			"dependencies": {
+				"@vue-macros/common": "^3.1.3",
+				"@vue/devtools-api": "^8.1.5",
+				"ast-walker-scope": "^0.9.0",
+				"chokidar": "^5.0.0",
+				"confbox": "^0.2.4",
+				"local-pkg": "^1.2.1",
+				"magic-string": "^0.30.21",
+				"mlly": "^1.8.2",
+				"muggle-string": "^0.4.1",
+				"nostics": "^1.1.4",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.5",
+				"scule": "^1.3.0",
+				"tinyglobby": "^0.2.17",
+				"unplugin": "^3.3.0",
+				"unplugin-utils": "^0.3.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/posva"
+			},
+			"peerDependencies": {
+				"@pinia/colada": ">=0.21.2",
+				"@vue/compiler-sfc": "^3.5.34 || ^4.0.0",
+				"pinia": "^3.0.4 || ^4.0.2",
+				"vite": "^7.3.0 || ^8.0.0",
+				"vue": "^3.5.34 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@pinia/colada": {
+					"optional": true
+				},
+				"@vue/compiler-sfc": {
+					"optional": true
+				},
+				"pinia": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -3160,6 +3957,18 @@
 			"dependencies": {
 				"eslint-scope": "5.1.1"
 			}
+		},
+		"node_modules/@nodable/entities": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+			"integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -3211,6 +4020,17 @@
 			"peer": true,
 			"engines": {
 				"node": ">=12.4.0"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.147.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+			"integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@parcel/watcher": {
@@ -3536,6 +4356,269 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
 			}
+		},
+		"node_modules/@rolldown/binding-android-arm-eabi": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+			"integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+			"integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+			"integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+			"integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+			"integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+			"integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+			"integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+			"integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+			"integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+			"integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+			"integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+			"integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+			"integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+			"integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+			"integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@rollup/plugin-inject": {
 			"version": "5.0.5",
@@ -4208,6 +5291,12 @@
 			"integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
 			"license": "MIT"
 		},
+		"node_modules/@types/toastify-js": {
+			"version": "1.12.4",
+			"resolved": "https://registry.npmjs.org/@types/toastify-js/-/toastify-js-1.12.4.tgz",
+			"integrity": "sha512-zfZHU4tKffPCnZRe7pjv/eFKzTVHozKewFCKaCjZ4gFinKgJRz/t0bkZiMCXJxPhv/ZoeDGNOeRD09R0kQZ/nw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -4793,54 +5882,93 @@
 				"vscode-uri": "^3.0.8"
 			}
 		},
-		"node_modules/@vue/compiler-core": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
-			"integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
+		"node_modules/@vue-macros/common": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.4.tgz",
+			"integrity": "sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.3",
-				"@vue/shared": "3.5.21",
-				"entities": "^4.5.0",
+				"@vue/compiler-sfc": "^3.5.22",
+				"ast-kit": "^2.1.2",
+				"local-pkg": "^1.1.2",
+				"magic-string-ast": "^1.0.2",
+				"unplugin-utils": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/vue-macros"
+			},
+			"peerDependencies": {
+				"vue": "^2.7.0 || ^3.2.25"
+			},
+			"peerDependenciesMeta": {
+				"vue": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vue/compiler-core": {
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+			"integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.8",
+				"@vue/shared": "3.5.42",
+				"entities": "^7.0.1",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.2.1"
 			}
 		},
+		"node_modules/@vue/compiler-core/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
-			"integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+			"integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-core": "3.5.21",
-				"@vue/shared": "3.5.21"
+				"@vue/compiler-core": "3.5.42",
+				"@vue/shared": "3.5.42"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
-			"integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+			"integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.3",
-				"@vue/compiler-core": "3.5.21",
-				"@vue/compiler-dom": "3.5.21",
-				"@vue/compiler-ssr": "3.5.21",
-				"@vue/shared": "3.5.21",
+				"@babel/parser": "^7.29.8",
+				"@vue/compiler-core": "3.5.42",
+				"@vue/compiler-dom": "3.5.42",
+				"@vue/compiler-ssr": "3.5.42",
+				"@vue/shared": "3.5.42",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.18",
-				"postcss": "^8.5.6",
+				"magic-string": "^0.30.21",
+				"postcss": "^8.5.19",
 				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
-			"integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+			"integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.21",
-				"@vue/shared": "3.5.21"
+				"@vue/compiler-dom": "3.5.42",
+				"@vue/shared": "3.5.42"
 			}
 		},
 		"node_modules/@vue/compiler-vue2": {
@@ -4854,10 +5982,22 @@
 				"he": "^1.2.0"
 			}
 		},
-		"node_modules/@vue/devtools-api": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-			"integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+		"node_modules/@vue/devtools-kit": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.2.1.tgz",
+			"integrity": "sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@vue/devtools-shared": "^8.2.1",
+				"birpc": "^2.6.1",
+				"hookable": "^5.5.3",
+				"perfect-debounce": "^2.0.0"
+			}
+		},
+		"node_modules/@vue/devtools-shared": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.2.1.tgz",
+			"integrity": "sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==",
 			"license": "MIT"
 		},
 		"node_modules/@vue/eslint-config-typescript": {
@@ -4912,59 +6052,57 @@
 			}
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
-			"integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.42.tgz",
+			"integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/shared": "3.5.21"
+				"@vue/shared": "3.5.42"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
-			"integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
+			"integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.21",
-				"@vue/shared": "3.5.21"
+				"@vue/reactivity": "3.5.42",
+				"@vue/shared": "3.5.42"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
-			"integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
+			"integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.5.21",
-				"@vue/runtime-core": "3.5.21",
-				"@vue/shared": "3.5.21",
-				"csstype": "^3.1.3"
+				"@vue/reactivity": "3.5.42",
+				"@vue/runtime-core": "3.5.42",
+				"@vue/shared": "3.5.42",
+				"csstype": "^3.2.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
-			"integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
+			"integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.5.21",
-				"@vue/shared": "3.5.21"
-			},
-			"peerDependencies": {
-				"vue": "3.5.21"
+				"@vue/compiler-ssr": "3.5.42",
+				"@vue/runtime-dom": "3.5.42",
+				"@vue/shared": "3.5.42"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
-			"integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+			"integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
 			"license": "MIT"
 		},
 		"node_modules/@vuepic/vue-datepicker": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.2.tgz",
-			"integrity": "sha512-uHh78mVBXCEjam1uVfTzZ/HkyDwut/H6b2djSN9YTF+l/EA+XONfdCnOVSi1g+qVGSy65DcQAwyBNidAssnudQ==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.3.tgz",
+			"integrity": "sha512-sb2adwqwK2PizLQOpxCYps2SwhVT6/ic2HMIOqHJXuYa6iAJZWGL5YVlS7O4aW+sk6ZyxlDURLO7kDZPL4HB/w==",
 			"license": "MIT",
 			"dependencies": {
 				"date-fns": "^4.1.0"
@@ -4977,27 +6115,27 @@
 			}
 		},
 		"node_modules/@vueuse/components": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-13.9.0.tgz",
-			"integrity": "sha512-0DDFpjG3hEEK+3YgSzE/OzOGqpo/KmxcXWzW2YdmgahZvaoUdegn68GmbdcHRJE7CH55dDj13Cz47iN8QoI3jQ==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/components/-/components-14.4.0.tgz",
+			"integrity": "sha512-USgxljmrGUTjtMJcOCbjU7SlRP6K1i5inM6JgMD8bOBn/oL4dK0XYTtNfWyuo0FgUhtCftIKXi+4vJ8ml+tmqw==",
 			"license": "MIT",
 			"dependencies": {
-				"@vueuse/core": "13.9.0",
-				"@vueuse/shared": "13.9.0"
+				"@vueuse/core": "14.4.0",
+				"@vueuse/shared": "14.4.0"
 			},
 			"peerDependencies": {
 				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/@vueuse/core": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
-			"integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
+			"integrity": "sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "13.9.0",
-				"@vueuse/shared": "13.9.0"
+				"@vueuse/metadata": "14.4.0",
+				"@vueuse/shared": "14.4.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -5007,18 +6145,18 @@
 			}
 		},
 		"node_modules/@vueuse/metadata": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
-			"integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.4.0.tgz",
+			"integrity": "sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/shared": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
-			"integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.4.0.tgz",
+			"integrity": "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -5028,10 +6166,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-			"dev": true,
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -5049,6 +6186,18 @@
 			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -5145,6 +6294,18 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
+		},
+		"node_modules/anynum": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
@@ -5318,6 +6479,7 @@
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.0.0",
@@ -5329,6 +6491,7 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/assert": {
@@ -5343,6 +6506,39 @@
 				"object-is": "^1.1.5",
 				"object.assign": "^4.1.4",
 				"util": "^0.12.5"
+			}
+		},
+		"node_modules/ast-kit": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+			"integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.28.5",
+				"pathe": "^2.0.3"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
+			}
+		},
+		"node_modules/ast-walker-scope": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.9.0.tgz",
+			"integrity": "sha512-IJdzo2vLiElBxKzwS36VsCue/62d6IdWjnPB2v3nuPKeWGynp6FF/CYoLa5i/3jXH/z97ZDdsXz6abpgM6w07A==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.2",
+				"@babel/types": "^7.29.0",
+				"ast-kit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
 			}
 		},
 		"node_modules/astral-regex": {
@@ -5377,6 +6573,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
@@ -5389,14 +6586,15 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-			"integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+			"integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.16.0",
+				"form-data": "^4.0.6",
+				"https-proxy-agent": "^5.0.1",
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
@@ -5458,15 +6656,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/base-64": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
 			"integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -5489,6 +6685,15 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/birpc": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+			"integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
 		"node_modules/blurhash": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
@@ -5499,6 +6704,7 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
 			"integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/boolbase": {
@@ -5513,7 +6719,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
 			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -5537,6 +6742,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browser-resolve": {
@@ -5553,6 +6759,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-xor": "^1.0.3",
@@ -5567,6 +6774,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserify-aes": "^1.0.4",
@@ -5578,6 +6786,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
@@ -5590,6 +6799,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
 			"integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^5.2.1",
@@ -5604,6 +6814,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
 			"integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"bn.js": "^5.2.1",
@@ -5625,12 +6836,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browserify-sign/node_modules/readable-stream": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
@@ -5646,12 +6859,14 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browserify-sign/node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
@@ -5661,6 +6876,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/browserify-zlib": {
@@ -5754,6 +6970,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/builtin-modules": {
@@ -5806,8 +7023,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/byte-length/-/byte-length-1.0.2.tgz",
 			"integrity": "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/cacheable": {
 			"version": "1.10.1",
@@ -5836,6 +7052,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
 			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
@@ -5867,6 +7084,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -5991,7 +7209,6 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
 			"license": "BSD-3-Clause",
-			"optional": true,
 			"engines": {
 				"node": "*"
 			}
@@ -6000,7 +7217,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
 			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -6017,6 +7234,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
 			"integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.4",
@@ -6120,10 +7338,9 @@
 			"license": "MIT"
 		},
 		"node_modules/confbox": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-			"dev": true,
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
 			"license": "MIT"
 		},
 		"node_modules/console-browserify": {
@@ -6176,6 +7393,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
@@ -6210,6 +7428,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
 			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
@@ -6220,12 +7439,14 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
@@ -6239,6 +7460,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.3",
@@ -6277,7 +7499,6 @@
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
 			"license": "BSD-3-Clause",
-			"optional": true,
 			"engines": {
 				"node": "*"
 			}
@@ -6286,6 +7507,7 @@
 			"version": "3.12.1",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
 			"integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserify-cipher": "^1.0.1",
@@ -6349,9 +7571,9 @@
 			}
 		},
 		"node_modules/csstype": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
 		"node_modules/data-uri-to-buffer": {
@@ -6359,7 +7581,6 @@
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
 			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">= 12"
 			}
@@ -6422,9 +7643,9 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -6439,12 +7660,12 @@
 			"license": "MIT"
 		},
 		"node_modules/debounce": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
-			"integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/debounce/-/debounce-3.0.0.tgz",
+			"integrity": "sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6492,6 +7713,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -6545,6 +7767,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
 			"integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.1",
@@ -6583,6 +7806,7 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
@@ -6594,6 +7818,7 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dir-glob": {
@@ -6685,9 +7910,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-			"integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+			"version": "3.4.14",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+			"integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -6734,6 +7959,7 @@
 			"version": "6.6.1",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
 			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.11.9",
@@ -6749,6 +7975,7 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/emoji-mart-vue-fast": {
@@ -6776,7 +8003,9 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -6958,7 +8187,7 @@
 			"version": "0.25.5",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
 			"integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-			"dev": true,
+			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -7802,9 +9031,9 @@
 			}
 		},
 		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
 			"license": "MIT"
 		},
 		"node_modules/events": {
@@ -7821,6 +9050,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"md5.js": "^1.3.4",
@@ -7828,10 +9058,9 @@
 			}
 		},
 		"node_modules/exsolve": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-			"integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-			"dev": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+			"integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
 			"license": "MIT"
 		},
 		"node_modules/extend": {
@@ -7912,11 +9141,10 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/fast-xml-parser": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-			"integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
-			"devOptional": true,
+		"node_modules/fast-xml-builder": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+			"integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
 			"funding": [
 				{
 					"type": "github",
@@ -7925,7 +9153,25 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"strnum": "^1.1.1"
+				"path-expression-matcher": "^1.6.2",
+				"xml-naming": "^0.3.0"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "4.5.7",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.7.tgz",
+			"integrity": "sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"strnum": "^1.0.5"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -7954,11 +9200,13 @@
 			}
 		},
 		"node_modules/fdir": {
-			"version": "6.4.6",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-			"integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-			"dev": true,
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
 			"peerDependencies": {
 				"picomatch": "^3 || ^4"
 			},
@@ -7983,7 +9231,6 @@
 				}
 			],
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"node-domexception": "^1.0.0",
 				"web-streams-polyfill": "^3.0.3"
@@ -8090,18 +9337,18 @@
 			}
 		},
 		"node_modules/focus-trap": {
-			"version": "7.6.5",
-			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
-			"integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.2.tgz",
+			"integrity": "sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==",
 			"license": "MIT",
 			"dependencies": {
-				"tabbable": "^6.2.0"
+				"tabbable": "^6.5.0"
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -8122,6 +9369,7 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-callable": "^1.2.7"
@@ -8134,16 +9382,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -8154,7 +9402,6 @@
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
 			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"fetch-blob": "^3.1.2"
 			},
@@ -8189,7 +9436,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -8544,6 +9790,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
@@ -8600,6 +9847,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
 			"integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.4",
@@ -8613,6 +9861,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -8620,9 +9869,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -8723,12 +9972,19 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
+		},
+		"node_modules/hookable": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+			"license": "MIT"
 		},
 		"node_modules/hookified": {
 			"version": "1.10.0",
@@ -8742,8 +9998,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-2.0.1.tgz",
 			"integrity": "sha512-ECg1JFG0YzehicQaogenlcs2qg6WsXQsxtnbr1i696u5tLUjtJdQAh0u2g0Q5YV45f263Ta1GnUJsc8WIfJf4Q==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/html-tags": {
 			"version": "3.3.1",
@@ -8787,17 +10042,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/humanize-duration": {
 			"version": "3.33.0",
 			"resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.33.0.tgz",
 			"integrity": "sha512-vYJX7BSzn7EQ4SaP2lPYVy+icHDppB6k7myNeI3wrSRfwMS5+BHyGgzpHR0ptqJ2AQ6UuIKrclSg5ve6Ci4IAQ==",
 			"license": "Unlicense"
-		},
-		"node_modules/ical.js": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
-			"integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
-			"license": "MPL-2.0"
 		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
@@ -8835,7 +10097,7 @@
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
 			"integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -8895,6 +10157,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ini": {
@@ -9067,8 +10330,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/is-builtin-module": {
 			"version": "3.2.1",
@@ -9116,6 +10378,7 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -9483,6 +10746,7 @@
 			"version": "1.1.15",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
@@ -9493,6 +10757,18 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/is-unsafe": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+			"integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/is-weakmap": {
 			"version": "2.0.2",
@@ -9547,6 +10823,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
 			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/isexe": {
@@ -9721,8 +10998,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
 			"integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
@@ -9739,6 +11015,290 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+			"license": "MPL-2.0",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.33.0",
+				"lightningcss-darwin-arm64": "1.33.0",
+				"lightningcss-darwin-x64": "1.33.0",
+				"lightningcss-freebsd-x64": "1.33.0",
+				"lightningcss-linux-arm-gnueabihf": "1.33.0",
+				"lightningcss-linux-arm64-gnu": "1.33.0",
+				"lightningcss-linux-arm64-musl": "1.33.0",
+				"lightningcss-linux-x64-gnu": "1.33.0",
+				"lightningcss-linux-x64-musl": "1.33.0",
+				"lightningcss-win32-arm64-msvc": "1.33.0",
+				"lightningcss-win32-x64-msvc": "1.33.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss/node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9748,21 +11308,20 @@
 			"peer": true
 		},
 		"node_modules/linkifyjs": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-			"integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+			"integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
 			"license": "MIT"
 		},
 		"node_modules/local-pkg": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-			"integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
-			"dev": true,
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+			"integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
 			"license": "MIT",
 			"dependencies": {
 				"mlly": "^1.7.4",
-				"pkg-types": "^2.0.1",
-				"quansync": "^0.2.8"
+				"pkg-types": "^2.3.0",
+				"quansync": "^0.2.11"
 			},
 			"engines": {
 				"node": ">=14"
@@ -9855,12 +11414,27 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.19",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-			"integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magic-string-ast": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
+			"integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
+			"license": "MIT",
+			"dependencies": {
+				"magic-string": "^0.30.19"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
 			}
 		},
 		"node_modules/material-colors": {
@@ -9895,7 +11469,6 @@
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
 			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
 			"license": "BSD-3-Clause",
-			"optional": true,
 			"dependencies": {
 				"charenc": "0.0.2",
 				"crypt": "0.0.2",
@@ -9906,6 +11479,7 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^3.0.0",
@@ -10629,6 +12203,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.0.0",
@@ -10642,6 +12217,7 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mime-db": {
@@ -10669,22 +12245,23 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
 			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"devOptional": true,
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -10705,30 +12282,27 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-			"integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-			"dev": true,
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+			"integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
 			"license": "MIT",
 			"dependencies": {
-				"acorn": "^8.14.0",
-				"pathe": "^2.0.1",
-				"pkg-types": "^1.3.0",
-				"ufo": "^1.5.4"
+				"acorn": "^8.16.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.3"
 			}
 		},
 		"node_modules/mlly/node_modules/confbox": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
 			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mlly/node_modules/pkg-types": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
 			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"confbox": "^0.1.8",
@@ -10756,13 +12330,12 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
 			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"funding": [
 				{
 					"type": "github",
@@ -10806,8 +12379,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
 			"integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/node-addon-api": {
 			"version": "7.1.1",
@@ -10834,7 +12406,6 @@
 				}
 			],
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">=10.5.0"
 			}
@@ -10844,7 +12415,6 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
 			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"data-uri-to-buffer": "^4.0.0",
 				"fetch-blob": "^3.1.4",
@@ -10921,6 +12491,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/nostics": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
+			"integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
+			"license": "MIT"
 		},
 		"node_modules/nth-check": {
 			"version": "2.1.1",
@@ -11142,28 +12718,28 @@
 			}
 		},
 		"node_modules/p-queue": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-			"integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
+			"version": "9.3.3",
+			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+			"integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
 			"license": "MIT",
 			"dependencies": {
-				"eventemitter3": "^5.0.1",
-				"p-timeout": "^6.1.2"
+				"eventemitter3": "^5.0.4",
+				"p-timeout": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-timeout": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-			"integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+			"integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -11207,6 +12783,7 @@
 			"version": "5.1.7",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
 			"integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"asn1.js": "^4.10.1",
@@ -11282,6 +12859,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+			"integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -11315,8 +12907,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
 			"integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA==",
-			"license": "ISC",
-			"optional": true
+			"license": "ISC"
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -11333,13 +12924,13 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pbkdf2": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
 			"integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"create-hash": "~1.1.3",
@@ -11357,6 +12948,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
 			"integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cipher-base": "^1.0.1",
@@ -11369,6 +12961,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
 			"integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.1"
@@ -11378,11 +12971,18 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
 			"integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^2.0.0",
 				"inherits": "^2.0.1"
 			}
+		},
+		"node_modules/perfect-debounce": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+			"integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -11391,10 +12991,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+			"integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -11417,14 +13016,13 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
-			"integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
-			"dev": true,
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+			"integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
 			"license": "MIT",
 			"dependencies": {
-				"confbox": "^0.2.2",
-				"exsolve": "^1.0.7",
+				"confbox": "^0.2.4",
+				"exsolve": "^1.0.8",
 				"pathe": "^2.0.3"
 			}
 		},
@@ -11432,15 +13030,16 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -11457,7 +13056,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -11600,6 +13199,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/property-information": {
@@ -11613,15 +13213,19 @@
 			}
 		},
 		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"license": "MIT"
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/public-encrypt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bn.js": "^4.1.0",
@@ -11636,6 +13240,7 @@
 			"version": "4.12.2",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
 			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/punycode": {
@@ -11665,10 +13270,9 @@
 			}
 		},
 		"node_modules/quansync": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-			"integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
-			"dev": true,
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+			"integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -11694,8 +13298,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
 			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -11723,6 +13326,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
@@ -11732,6 +13336,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"randombytes": "^2.0.5",
@@ -11757,7 +13362,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
 			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -12025,8 +13630,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"license": "MIT",
-			"optional": true
+			"license": "MIT"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
@@ -12116,17 +13720,53 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+			"integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@oxc-project/types": "=0.147.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm-eabi": "1.2.6",
+				"@rolldown/binding-android-arm64": "1.2.6",
+				"@rolldown/binding-darwin-arm64": "1.2.6",
+				"@rolldown/binding-darwin-x64": "1.2.6",
+				"@rolldown/binding-freebsd-x64": "1.2.6",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.6",
+				"@rolldown/binding-linux-arm64-musl": "1.2.6",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.6",
+				"@rolldown/binding-linux-x64-gnu": "1.2.6",
+				"@rolldown/binding-linux-x64-musl": "1.2.6",
+				"@rolldown/binding-openharmony-arm64": "1.2.6",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.6",
+				"@rolldown/binding-win32-x64-msvc": "1.2.6"
+			}
+		},
 		"node_modules/rollup": {
 			"version": "4.44.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
 			"integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -12295,6 +13935,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -12351,7 +13992,7 @@
 			"version": "1.89.2",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
 			"integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -12375,6 +14016,12 @@
 			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
 			"license": "ISC"
 		},
+		"node_modules/scule": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+			"integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -12390,6 +14037,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -12447,6 +14095,7 @@
 			"version": "2.4.12",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
 			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+			"dev": true,
 			"license": "(MIT AND BSD-3-Clause)",
 			"dependencies": {
 				"inherits": "^2.0.4",
@@ -12962,14 +14611,15 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
 			"integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/strtok3": {
 			"version": "10.3.4",
@@ -13415,9 +15065,9 @@
 			"peer": true
 		},
 		"node_modules/tabbable": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
 			"license": "MIT"
 		},
 		"node_modules/table": {
@@ -13486,15 +15136,13 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.14",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-			"dev": true,
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -13507,6 +15155,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
 			"integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"isarray": "^2.0.5",
@@ -13530,6 +15179,12 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/toastify-js": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.12.0.tgz",
+			"integrity": "sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ==",
+			"license": "MIT"
 		},
 		"node_modules/tributejs": {
 			"version": "5.1.3",
@@ -13569,6 +15224,15 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
+			}
+		},
+		"node_modules/ts-md5": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-2.0.1.tgz",
+			"integrity": "sha512-yF35FCoEOFBzOclSkMNEUbFQZuv89KEQ+5Xz03HrMSGUGB1+r+El+JiGOFwsP4p9RFNzwlrydYoTLvPOuICl9w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -13647,6 +15311,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
 			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.3",
@@ -13739,17 +15404,15 @@
 			}
 		},
 		"node_modules/typescript-event-target": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
-			"integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
-			"license": "MIT",
-			"optional": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.2.tgz",
+			"integrity": "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw==",
+			"license": "MIT"
 		},
 		"node_modules/ufo": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-			"dev": true,
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+			"integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
 			"license": "MIT"
 		},
 		"node_modules/unbox-primitive": {
@@ -13921,9 +15584,9 @@
 			}
 		},
 		"node_modules/unist-util-visit-parents": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -13942,6 +15605,76 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/unplugin": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+			"integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/remapping": "^2.3.5",
+				"picomatch": "^4.0.4",
+				"webpack-virtual-modules": "^0.6.2"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"peerDependencies": {
+				"@farmfe/core": "*",
+				"@rspack/core": "*",
+				"bun-types-no-globals": "*",
+				"esbuild": "*",
+				"rolldown": "*",
+				"rollup": "*",
+				"unloader": "*",
+				"vite": "*",
+				"webpack": "*"
+			},
+			"peerDependenciesMeta": {
+				"@farmfe/core": {
+					"optional": true
+				},
+				"@rspack/core": {
+					"optional": true
+				},
+				"bun-types-no-globals": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"rolldown": {
+					"optional": true
+				},
+				"rollup": {
+					"optional": true
+				},
+				"unloader": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/unplugin-utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+			"integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sxzz"
 			}
 		},
 		"node_modules/unrs-resolver": {
@@ -14040,7 +15773,6 @@
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
 			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
@@ -14050,7 +15782,6 @@
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
 			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
@@ -14081,6 +15812,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/vfile": {
@@ -14115,7 +15847,7 @@
 			"version": "6.3.5",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
 			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -14347,16 +16079,16 @@
 			"license": "MIT"
 		},
 		"node_modules/vue": {
-			"version": "3.5.21",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.21.tgz",
-			"integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
+			"version": "3.5.42",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.42.tgz",
+			"integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.5.21",
-				"@vue/compiler-sfc": "3.5.21",
-				"@vue/runtime-dom": "3.5.21",
-				"@vue/server-renderer": "3.5.21",
-				"@vue/shared": "3.5.21"
+				"@vue/compiler-dom": "3.5.42",
+				"@vue/compiler-sfc": "3.5.42",
+				"@vue/runtime-dom": "3.5.42",
+				"@vue/server-renderer": "3.5.42",
+				"@vue/shared": "3.5.42"
 			},
 			"peerDependencies": {
 				"typescript": "*"
@@ -14459,56 +16191,30 @@
 				"vue": "^3.0.0"
 			}
 		},
-		"node_modules/vue-router": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
-			"integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/devtools-api": "^6.6.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/posva"
-			},
-			"peerDependencies": {
-				"vue": "^3.2.0"
-			}
-		},
-		"node_modules/vue-select": {
-			"version": "4.0.0-beta.6",
-			"resolved": "https://registry.npmjs.org/vue-select/-/vue-select-4.0.0-beta.6.tgz",
-			"integrity": "sha512-K+zrNBSpwMPhAxYLTCl56gaMrWZGgayoWCLqe5rWwkB8aUbAUh7u6sXjIR7v4ckp2WKC7zEEUY27g6h1MRsIHw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"vue": "3.x"
-			}
-		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
 			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/webdav": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/webdav/-/webdav-5.8.0.tgz",
-			"integrity": "sha512-iuFG7NamJ41Oshg4930iQgfIpRrUiatPWIekeznYgEf2EOraTRcDPTjy7gIOMtkdpKTaqPk1E68NO5PAGtJahA==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/webdav/-/webdav-5.10.0.tgz",
+			"integrity": "sha512-fVPuRLtcduVGvSO7Tn/6TQCzIvI/g6BO/+xPRctCvi/GytYpjn4czxWbh4HsArsdom9qz9BI63k9/v2HBUui1A==",
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"@buttercup/fetch": "^0.2.1",
 				"base-64": "^1.0.0",
 				"byte-length": "^1.0.2",
-				"entities": "^6.0.0",
-				"fast-xml-parser": "^4.5.1",
+				"entities": "^6.0.1",
+				"fast-xml-parser": "^5.7.2",
 				"hot-patcher": "^2.0.1",
 				"layerr": "^3.0.0",
 				"md5": "^2.3.0",
-				"minimatch": "^9.0.5",
+				"minimatch": "^9.0.9",
 				"nested-property": "^4.0.0",
 				"node-fetch": "^3.3.2",
 				"path-posix": "^1.0.0",
@@ -14524,13 +16230,56 @@
 			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
 			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
 			"license": "BSD-2-Clause",
-			"optional": true,
 			"engines": {
 				"node": ">=0.12"
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
+		},
+		"node_modules/webdav/node_modules/fast-xml-parser": {
+			"version": "5.11.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.1.tgz",
+			"integrity": "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^3.0.0",
+				"fast-xml-builder": "^1.2.0",
+				"is-unsafe": "^2.0.0",
+				"path-expression-matcher": "^1.6.2",
+				"strnum": "^2.4.2",
+				"xml-naming": "^0.3.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/webdav/node_modules/strnum": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+			"integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"anynum": "^1.0.1"
+			}
+		},
+		"node_modules/webpack-virtual-modules": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -14623,6 +16372,7 @@
 			"version": "1.1.19",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
 			"integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
@@ -14683,6 +16433,21 @@
 			"peer": true,
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+			"integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/axios": "2.5.1",
-				"@nextcloud/dialogs": "7.3.0",
+				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/initial-state": "^2.2.0",
 				"@nextcloud/router": "^3.0.1",
 				"@nextcloud/vue": "^9.0.0-rc.9",
@@ -1830,7 +1830,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1847,7 +1846,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1864,7 +1862,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1881,7 +1878,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1898,7 +1894,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1915,7 +1910,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1932,7 +1926,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1949,7 +1942,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1966,7 +1958,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1983,7 +1974,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2000,7 +1990,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2017,7 +2006,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2034,7 +2022,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2051,7 +2038,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2068,7 +2054,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2085,7 +2070,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2102,7 +2086,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2119,7 +2102,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2136,7 +2118,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2153,7 +2134,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2170,29 +2150,11 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"openbsd"
 			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
-			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2204,7 +2166,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2221,7 +2182,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2238,7 +2198,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2255,7 +2214,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2835,29 +2793,28 @@
 			}
 		},
 		"node_modules/@nextcloud/dialogs": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-7.3.0.tgz",
-			"integrity": "sha512-pFuM10Dkvip+wSBaElcbSAN7Jynp41HJUh5kndRYpJipYl0SpNfjIe32+uNfOI43/tln4ScTlrfjIX6cK+3uHg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-7.5.0.tgz",
+			"integrity": "sha512-2gmv0V3ObphxRd7ZvXwTsPvn/XSf2vummdXb2LRFpkoSamWbk+41SWv7cnDQPC+Ve9p46WebDuqyG+wbefkhEw==",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@mdi/js": "^7.4.47",
-				"@nextcloud/auth": "^2.5.3",
-				"@nextcloud/axios": "^2.5.2",
+				"@nextcloud/auth": "^2.6.0",
+				"@nextcloud/axios": "^2.6.0",
 				"@nextcloud/browser-storage": "^0.5.0",
+				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/event-bus": "^3.3.3",
 				"@nextcloud/files": "^4.0.0",
 				"@nextcloud/initial-state": "^3.0.0",
 				"@nextcloud/l10n": "^3.4.1",
-				"@nextcloud/paths": "^3.0.0",
+				"@nextcloud/paths": "^3.1.0",
 				"@nextcloud/router": "^3.1.0",
 				"@nextcloud/sharing": "^0.4.0",
-				"@nextcloud/vue": "^9.5.0",
-				"@types/toastify-js": "^1.12.4",
-				"@vueuse/core": "^14.2.1",
-				"p-queue": "^9.0.1",
-				"toastify-js": "^1.12.0",
-				"vue": "^3.5.28",
-				"webdav": "^5.8.0"
+				"@nextcloud/vue": "^9.9.0",
+				"@vueuse/core": "^14.4.0",
+				"p-queue": "^9.3.3",
+				"vue": "^3.5.41",
+				"webdav": "^5.10.0"
 			},
 			"engines": {
 				"node": "^20 || ^22 || ^24"
@@ -3293,431 +3250,6 @@
 				"vue": "^3"
 			}
 		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
-			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/android-arm": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
-			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/android-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
-			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/android-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
-			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
-			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
-			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
-			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
-			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-arm": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
-			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
-			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
-			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
-			"cpu": [
-				"ia32"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
-			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
-			"cpu": [
-				"loong64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
-			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
-			"cpu": [
-				"mips64el"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
-			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
-			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
-			"cpu": [
-				"riscv64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
-			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
-			"cpu": [
-				"s390x"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/linux-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
-			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
-			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
-			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
-			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
-			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
-			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
-			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
-			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
-			"cpu": [
-				"ia32"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@esbuild/win32-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
-			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@nextcloud/vue/node_modules/@nextcloud/axios": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.6.0.tgz",
@@ -3764,49 +3296,6 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/@nextcloud/vue/node_modules/esbuild": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
-			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.2",
-				"@esbuild/android-arm": "0.28.2",
-				"@esbuild/android-arm64": "0.28.2",
-				"@esbuild/android-x64": "0.28.2",
-				"@esbuild/darwin-arm64": "0.28.2",
-				"@esbuild/darwin-x64": "0.28.2",
-				"@esbuild/freebsd-arm64": "0.28.2",
-				"@esbuild/freebsd-x64": "0.28.2",
-				"@esbuild/linux-arm": "0.28.2",
-				"@esbuild/linux-arm64": "0.28.2",
-				"@esbuild/linux-ia32": "0.28.2",
-				"@esbuild/linux-loong64": "0.28.2",
-				"@esbuild/linux-mips64el": "0.28.2",
-				"@esbuild/linux-ppc64": "0.28.2",
-				"@esbuild/linux-riscv64": "0.28.2",
-				"@esbuild/linux-s390x": "0.28.2",
-				"@esbuild/linux-x64": "0.28.2",
-				"@esbuild/netbsd-arm64": "0.28.2",
-				"@esbuild/netbsd-x64": "0.28.2",
-				"@esbuild/openbsd-arm64": "0.28.2",
-				"@esbuild/openbsd-x64": "0.28.2",
-				"@esbuild/openharmony-arm64": "0.28.2",
-				"@esbuild/sunos-x64": "0.28.2",
-				"@esbuild/win32-arm64": "0.28.2",
-				"@esbuild/win32-ia32": "0.28.2",
-				"@esbuild/win32-x64": "0.28.2"
-			}
-		},
 		"node_modules/@nextcloud/vue/node_modules/readdirp": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
@@ -3818,85 +3307,6 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/vite": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
-			"integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"lightningcss": "^1.33.0",
-				"picomatch": "^4.0.5",
-				"postcss": "^8.5.26",
-				"rolldown": "~1.2.4",
-				"tinyglobby": "^0.2.17"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.4.0 || ^0.5.0",
-				"esbuild": "^0.27.0 || ^0.28.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"@vitejs/devtools": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"jiti": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@nextcloud/vue/node_modules/vue-router": {
@@ -4022,22 +3432,10 @@
 				"node": ">=12.4.0"
 			}
 		},
-		"node_modules/@oxc-project/types": {
-			"version": "0.147.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
-			"integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/Boshen"
-			}
-		},
 		"node_modules/@parcel/watcher": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
 			"integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -4078,7 +3476,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4100,7 +3497,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4122,7 +3518,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4144,7 +3539,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4166,7 +3560,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4188,7 +3581,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4210,7 +3602,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4232,7 +3623,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4254,7 +3644,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4276,7 +3665,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4298,7 +3686,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4320,7 +3707,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4342,7 +3728,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4356,269 +3741,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
 			}
-		},
-		"node_modules/@rolldown/binding-android-arm-eabi": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
-			"integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
-			"integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
-			"integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
-			"integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
-			"integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
-			"integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
-			"cpu": [
-				"arm"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
-			"integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
-			"integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
-			"integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
-			"integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
-			"cpu": [
-				"s390x"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
-			"integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
-			"integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
-			"integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
-			"integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
-			"integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
-		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/@rollup/plugin-inject": {
 			"version": "5.0.5",
@@ -4695,7 +3817,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4710,7 +3831,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4725,7 +3845,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4740,7 +3859,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4755,7 +3873,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4770,7 +3887,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4785,7 +3901,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4800,7 +3915,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4815,7 +3929,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4830,7 +3943,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4845,7 +3957,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4860,7 +3971,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4875,7 +3985,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4890,7 +3999,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4905,7 +4013,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4920,7 +4027,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4935,7 +4041,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4950,7 +4055,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4965,7 +4069,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4980,7 +4083,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5289,12 +4391,6 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
 			"integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
-			"license": "MIT"
-		},
-		"node_modules/@types/toastify-js": {
-			"version": "1.12.4",
-			"resolved": "https://registry.npmjs.org/@types/toastify-js/-/toastify-js-1.12.4.tgz",
-			"integrity": "sha512-zfZHU4tKffPCnZRe7pjv/eFKzTVHozKewFCKaCjZ4gFinKgJRz/t0bkZiMCXJxPhv/ZoeDGNOeRD09R0kQZ/nw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/trusted-types": {
@@ -6728,7 +5824,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -7778,7 +6874,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"peer": true,
@@ -9257,7 +8352,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -10454,7 +9549,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -10512,7 +9607,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -10581,7 +9676,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -11013,290 +10108,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/lightningcss": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-			"license": "MPL-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"detect-libc": "^2.0.3"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			},
-			"optionalDependencies": {
-				"lightningcss-android-arm64": "1.33.0",
-				"lightningcss-darwin-arm64": "1.33.0",
-				"lightningcss-darwin-x64": "1.33.0",
-				"lightningcss-freebsd-x64": "1.33.0",
-				"lightningcss-linux-arm-gnueabihf": "1.33.0",
-				"lightningcss-linux-arm64-gnu": "1.33.0",
-				"lightningcss-linux-arm64-musl": "1.33.0",
-				"lightningcss-linux-x64-gnu": "1.33.0",
-				"lightningcss-linux-x64-musl": "1.33.0",
-				"lightningcss-win32-arm64-msvc": "1.33.0",
-				"lightningcss-win32-x64-msvc": "1.33.0"
-			}
-		},
-		"node_modules/lightningcss-android-arm64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-darwin-arm64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-darwin-x64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-freebsd-x64": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-arm-gnueabihf": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-arm64-gnu": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-arm64-musl": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-x64-gnu": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-linux-x64-musl": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-win32-arm64-msvc": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss-win32-x64-msvc": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MPL-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/lightningcss/node_modules/detect-libc": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/lines-and-columns": {
@@ -12174,7 +10985,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -12189,7 +11000,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -12385,7 +11196,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"peer": true
@@ -13725,41 +12535,6 @@
 			"dependencies": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
-			}
-		},
-		"node_modules/rolldown": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
-			"integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@oxc-project/types": "=0.147.0",
-				"@rolldown/pluginutils": "^1.0.0"
-			},
-			"bin": {
-				"rolldown": "bin/cli.mjs"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"optionalDependencies": {
-				"@rolldown/binding-android-arm-eabi": "1.2.6",
-				"@rolldown/binding-android-arm64": "1.2.6",
-				"@rolldown/binding-darwin-arm64": "1.2.6",
-				"@rolldown/binding-darwin-x64": "1.2.6",
-				"@rolldown/binding-freebsd-x64": "1.2.6",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
-				"@rolldown/binding-linux-arm64-gnu": "1.2.6",
-				"@rolldown/binding-linux-arm64-musl": "1.2.6",
-				"@rolldown/binding-linux-ppc64-gnu": "1.2.6",
-				"@rolldown/binding-linux-s390x-gnu": "1.2.6",
-				"@rolldown/binding-linux-x64-gnu": "1.2.6",
-				"@rolldown/binding-linux-x64-musl": "1.2.6",
-				"@rolldown/binding-openharmony-arm64": "1.2.6",
-				"@rolldown/binding-win32-arm64-msvc": "1.2.6",
-				"@rolldown/binding-win32-x64-msvc": "1.2.6"
 			}
 		},
 		"node_modules/rollup": {
@@ -15170,7 +13945,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -15179,12 +13954,6 @@
 			"engines": {
 				"node": ">=8.0"
 			}
-		},
-		"node_modules/toastify-js": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/toastify-js/-/toastify-js-1.12.0.tgz",
-			"integrity": "sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ==",
-			"license": "MIT"
 		},
 		"node_modules/tributejs": {
 			"version": "5.1.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"type": "module",
 	"dependencies": {
 		"@nextcloud/axios": "2.5.1",
-		"@nextcloud/dialogs": "7.3.0",
+		"@nextcloud/dialogs": "^7.3.0",
 		"@nextcloud/initial-state": "^2.2.0",
 		"@nextcloud/router": "^3.0.1",
 		"@nextcloud/vue": "^9.0.0-rc.9",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@nextcloud/axios": "2.5.1",
+		"@nextcloud/dialogs": "7.3.0",
 		"@nextcloud/initial-state": "^2.2.0",
 		"@nextcloud/router": "^3.0.1",
 		"@nextcloud/vue": "^9.0.0-rc.9",

--- a/src/components/ViewAdmin.vue
+++ b/src/components/ViewAdmin.vue
@@ -66,6 +66,28 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<p>{{ t('context_chat', 'Queued content update actions: {count}', {count: stats.queued_actions_count}) }}</p>
 		<p>{{ t('context_chat', 'Locked queue content update actions: {count}', {count: stats.queued_actions_locked_count}) }}</p>
 		<p>{{ t('context_chat', 'Queued file system events: {count}', {count: stats.queued_fs_events_count}) }}</p>
+
+		<h3>{{ t('context_chat', 'Indexing mode') }}</h3>
+		<NcCheckboxRadioSwitch
+			:model-value="indexMode"
+			value="all"
+			name="index_mode_radio"
+			type="radio"
+			@update:model-value="onIndexModeChange('all')">
+			{{ t('context_chat', 'Index all documents') }}
+		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch
+			:model-value="indexMode"
+			value="tag_only"
+			name="index_mode_radio"
+			type="radio"
+			@update:model-value="onIndexModeChange('tag_only')">
+			{{ t('context_chat', "Index only documents tagged 'AI knowledge'") }}
+		</NcCheckboxRadioSwitch>
+		<NcNoteCard type="warning">
+			{{ t('context_chat', "When 'Index only documents tagged AI knowledge' is selected, only documents with that tag are indexed, and any previously indexed documents without it are removed from the index. Add the tag to any document you want indexed.") }}
+		</NcNoteCard>
+
 		<h3>{{ t('context_chat', 'Download Logs') }}</h3>
 		<div class="horizontal-flex">
 			<NcButton :href="downloadURLNextcloudLogs">
@@ -85,20 +107,24 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </template>
 
 <script>
+import axios from '@nextcloud/axios'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import '@nextcloud/dialogs/style.css'
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
-import { NcButton, NcNoteCard, NcSettingsSection } from '@nextcloud/vue'
+import { NcButton, NcCheckboxRadioSwitch, NcNoteCard, NcSettingsSection } from '@nextcloud/vue'
 import humanizeDuration from 'humanize-duration'
 
 const MAX_RELATIVE_DATE = 1000 * 60 * 60 * 24 * 7 // one week
 
 export default {
 	name: 'ViewAdmin',
-	components: { NcSettingsSection, NcNoteCard, NcButton },
+	components: { NcSettingsSection, NcNoteCard, NcButton, NcCheckboxRadioSwitch },
 
 	data() {
 		return {
 			stats: {},
+			indexMode: 'all',
 			downloadURLNextcloudLogs: generateUrl('/apps/context_chat/download-logs-nextcloud'),
 			downloadURLDockerLogs: generateUrl('/apps/app_api/proxy/context_chat_backend/downloadLogs'),
 		}
@@ -112,6 +138,7 @@ export default {
 	},
 	async created() {
 		this.stats = loadState('context_chat', 'stats')
+		this.indexMode = loadState('context_chat', 'index_mode')
 	},
 
 	methods: {
@@ -131,6 +158,22 @@ export default {
 				return this.t('context_chat', '{time} ago', { time: duration })
 			} else {
 				return date.toLocaleDateString()
+			}
+		},
+		async onIndexModeChange(newValue) {
+			if (newValue === this.indexMode) {
+				return
+			}
+			const previousValue = this.indexMode
+			this.indexMode = newValue
+			try {
+				await axios.put(generateUrl('/apps/context_chat/admin-config'), {
+					values: { index_mode: newValue },
+				})
+				showSuccess(this.t('context_chat', 'Context Chat admin options saved'))
+			} catch (error) {
+				this.indexMode = previousValue
+				showError(this.t('context_chat', 'Failed to save indexing mode'))
 			}
 		},
 	},


### PR DESCRIPTION
Fixes #278. 

## Why this matters

Context Chat currently indexes every document matching its mimetype whitelist, with no way to exclude anything. For organizations handling sensitive or confidential material — legal, healthcare, HR, compliance-regulated industries — there's currently no way to control which content gets sent to an LLM for embedding. Everything eligible is indexed by default, which is the wrong default for these environments: it means adopting Context Chat requires either accepting that every eligible document becomes part of the AI's knowledge base, or not adopting it at all.

This PR takes an allow-list approach rather than a block-list one, on purpose: with an allow-list, nothing is exposed to the AI unless someone explicitly marks it as safe to include. A block-list ("index everything except X") is easy to get wrong by omission — someone forgets to exclude a folder, and it's silently indexed. An allow-list fails safe: if you forget to tag something, it simply isn't indexed, which is the safer failure mode for sensitive content.

This also has to work for instances that are already running Context Chat today, with documents already indexed under the existing "index everything" behavior. The feature is opt-in: existing instances keep indexing everything by default, and only change behavior if an admin deliberately switches modes. Nothing changes for anyone who doesn't touch the new setting.

## How it works

Admins get a new toggle on the Context Chat admin settings page:

- **Index all documents** (default, existing behavior, unchanged)
- **Index only documents tagged 'AI knowledge'**

The tag is a regular Nextcloud system tag, so it uses infrastructure that already exists and that admins/users already understand, rather than introducing a new concept. Tagging a folder covers everything inside it (tag inheritance walks up the file's ancestor folders), so an admin can mark, say, a single top-level "AI knowledge" folder and everything moved into it becomes eligible, without needing to tag every individual file.

Switching modes has real consequences that need to happen automatically, not just at settings-save time:

- Switching **to** tag-only mode schedules a background cleanup that walks every file already in the index and removes anything that isn't tagged. Otherwise, documents indexed before the switch would silently remain searchable forever, defeating the point of the feature.
- Switching **back to** "all" triggers a full reindex, since documents that were previously excluded (or never indexed because they didn't have the tag) need to be picked up.

Both of these are background jobs, not something the admin has to wait on synchronously — the admin page's indexing status (already existing in Context Chat) reflects live progress for both flows, so the admin can see when the switch has actually finished taking effect, not just when the setting was saved.

## Design decisions worth calling out

**Why extend the existing event-listener pattern instead of a new mechanism:** Nextcloud already has a system tag mechanism and Context Chat already listens for filesystem events (`FileListener.php`) to decide what to index. This PR follows that same shape, listening for `TagAssignedEvent`/`TagUnassignedEvent` in addition to the existing file events, rather than introducing a parallel, separate indexing pipeline just for tags.

**Why the completion-check logic was extracted and rewritten, not just extended:** The existing "has initial indexing completed?" check relied on a single global `last_enqueued_db_id` marker. On instances with multiple users (each with their own storage), that marker gets overwritten by whichever user's crawl job runs last — so a small storage finishing first could make the check falsely report "complete" while a larger storage still had thousands of files queued. This is a pre-existing issue that became directly relevant here because the new tag-cleanup job needed the same completion check, and duplicating the flawed logic would have meant two places to fix later instead of one. The rewritten check (`IndexCompletionService`) verifies live state instead — are there still crawl jobs of either kind scheduled, are there still files in the queue, are there still pending queue actions — rather than trusting a single stored marker that can go stale.

**Why the config cache is cleared explicitly after saving:** Nextcloud's app config layer is cached (APCu) and shared across PHP processes, including the long-running background worker process. Without clearing the cache after saving `index_mode`, the worker could keep operating on the old value for some time after the admin toggled the setting, even though the database already had the new value.

## Changes

- `lib/Service/FsEventService.php`: `hasAiKnowledgeTag()` checks the "AI knowledge" tag on a node and walks up its ancestors for folder-level inheritance; returns `true` unconditionally when the app is in "index all" mode, so tag-checking has zero effect on existing installs that don't opt in
- `lib/Controller/ConfigController.php`: `handleIndexModeChange()` detects an actual mode change (not just any settings save) and schedules the appropriate background job; also clears the app config cache after saving
- `lib/BackgroundJobs/UntaggedCleanupSchedulerJob.php` + `UntaggedCleanupCrawlJob.php`: discover all mounts and remove untagged documents from the index in batches, mirroring the existing `SchedulerJob`/`StorageCrawlJob` shape rather than introducing a different batching pattern
- `lib/Command/CleanupUntagged.php`: `occ context_chat:cleanup-untagged` command to trigger the same cleanup manually, useful for admins scripting deployment or recovering from an interrupted run
- `lib/Service/IndexCompletionService.php`: extracted from `QueueController` for the reasons above, and used by both the normal indexing flow and the new tag-cleanup flow
- `src/components/ViewAdmin.vue`: admin UI for the mode toggle; the UI update is optimistic (switches immediately for responsiveness) and reverts to the previous value if the save request fails, so the displayed state never lies about what's actually saved

## Testing

Tested end-to-end on a real multi-user Nextcloud instance: tagged specific folders and individual files, confirmed tagged documents get indexed and untagged ones get removed, confirmed folder-tag inheritance works correctly for files inside a tagged folder, confirmed switching modes back and forth triggers the correct job each time, confirmed the admin page's status accurately reflects "running" vs "finished" throughout both flows (including across multiple users' storages, which is what surfaced the completion-check issue described above), and confirmed a real Context Chat query only returns tagged sources when tag-only mode is active.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
